### PR TITLE
feat: load partner data from json

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // src/theme.ts
 function isDark() {
   return document.body.classList.contains("dark-mode") || !document.body.classList.contains("light-mode") && window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -1516,9 +1517,47 @@ if (backToTop) {
     });
   });
 }
+async function loadPartners() {
+  const container = document.getElementById("partners-grid");
+  if (!container) return;
+  try {
+    await loadLanguage(currentLang);
+    const resp = await fetch("partners.json");
+    if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+    const partners = await resp.json();
+    partners.forEach((p) => {
+      const item = document.createElement("div");
+      item.className = "logo-item";
+      const link = document.createElement("a");
+      link.href = p.url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      const img = document.createElement("img");
+      img.src = p.logo;
+      img.alt = p.alt;
+      img.loading = "lazy";
+      const icon = document.createElement("i");
+      icon.className = "material-symbols-outlined";
+      icon.setAttribute("aria-hidden", "true");
+      icon.textContent = p.icon;
+      const name = document.createElement("span");
+      name.setAttribute("data-i18n", p.nameKey);
+      name.textContent = translate(p.nameKey);
+      const desc = document.createElement("p");
+      desc.setAttribute("data-i18n", p.descKey);
+      desc.textContent = translate(p.descKey);
+      link.append(img, icon, name, desc);
+      item.append(link);
+      container.append(item);
+    });
+  } catch (err) {
+    console.error("Failed to load partners:", err);
+  }
+}
 initTheme();
 initI18n();
 loadStakingStatus();
+loadPartners();
 /*! Bundled license information:
 
 dompurify/dist/purify.es.mjs:

--- a/index.html
+++ b/index.html
@@ -669,39 +669,7 @@
 
       <section id="partners">
         <h2 data-i18n="partners_title">파트너</h2>
-        <div class="logo-grid">
-          <div class="logo-item">
-            <img
-              src="./assets/music-chain-logo.svg"
-              alt="MusicChain logo"
-              loading="lazy"
-            />
-            <i class="material-symbols-outlined" aria-hidden="true"
-              >music_note</i
-            >
-            <span data-i18n="partner1">뮤직체인</span>
-          </div>
-          <div class="logo-item">
-            <img
-              src="./assets/game-world-logo.svg"
-              alt="GameWorld logo"
-              loading="lazy"
-            />
-            <i class="material-symbols-outlined" aria-hidden="true"
-              >sports_esports</i
-            >
-            <span data-i18n="partner2">게임월드</span>
-          </div>
-          <div class="logo-item">
-            <img
-              src="./assets/entermedia-logo.svg"
-              alt="EnterMedia logo"
-              loading="lazy"
-            />
-            <i class="material-symbols-outlined" aria-hidden="true">movie</i>
-            <span data-i18n="partner3">엔터미디어</span>
-          </div>
-        </div>
+        <div class="logo-grid" id="partners-grid"></div>
       </section>
 
       <section id="resources">

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -177,5 +177,8 @@
   "theme_switched": "تم التبديل إلى وضع {{mode}}",
   "alt_daniel": "صورة لدانيال كيم، المدير التنفيذي والمؤسس المشارك",
   "alt_emily": "صورة لإميلي لي، المديرة التقنية",
-  "alt_michael": "صورة لمايكل بارك، كبير مهندسي البلوك تشين"
+  "alt_michael": "صورة لمايكل بارك، كبير مهندسي البلوك تشين",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -177,5 +177,8 @@
   "theme_switched": "Zum {{mode}}-Modus gewechselt",
   "alt_daniel": "Porträt von Daniel Kim, CEO & Mitbegründer",
   "alt_emily": "Porträt von Emily Lee, CTO",
-  "alt_michael": "Porträt von Michael Park, leitender Blockchain-Ingenieur"
+  "alt_michael": "Porträt von Michael Park, leitender Blockchain-Ingenieur",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -177,5 +177,8 @@
   "theme_switched": "Switched to {{mode}} mode",
   "alt_daniel": "Portrait of Daniel Kim, CEO & Co-Founder",
   "alt_emily": "Portrait of Emily Lee, CTO",
-  "alt_michael": "Portrait of Michael Park, Lead Blockchain Engineer"
+  "alt_michael": "Portrait of Michael Park, Lead Blockchain Engineer",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -177,5 +177,8 @@
   "theme_switched": "Se cambió al modo {{mode}}",
   "alt_daniel": "Retrato de Daniel Kim, CEO y cofundador",
   "alt_emily": "Retrato de Emily Lee, CTO",
-  "alt_michael": "Retrato de Michael Park, ingeniero líder de blockchain"
+  "alt_michael": "Retrato de Michael Park, ingeniero líder de blockchain",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -177,5 +177,8 @@
   "theme_switched": "Passé en mode {{mode}}",
   "alt_daniel": "Portrait de Daniel Kim, PDG et cofondateur",
   "alt_emily": "Portrait d'Emily Lee, CTO",
-  "alt_michael": "Portrait de Michael Park, ingénieur principal blockchain"
+  "alt_michael": "Portrait de Michael Park, ingénieur principal blockchain",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -177,5 +177,8 @@
   "theme_switched": "{{mode}} मोड में बदला गया",
   "alt_daniel": "डैनियल किम का चित्र, CEO और सह-संस्थापक",
   "alt_emily": "एमिली ली का चित्र, CTO",
-  "alt_michael": "माइकल पार्क का चित्र, प्रमुख ब्लॉकचेन इंजीनियर"
+  "alt_michael": "माइकल पार्क का चित्र, प्रमुख ब्लॉकचेन इंजीनियर",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -177,5 +177,8 @@
   "theme_switched": "{{mode}}モードに切り替えました",
   "alt_daniel": "CEO兼共同創設者ダニエル・キムの肖像",
   "alt_emily": "CTOエミリー・リーの肖像",
-  "alt_michael": "リードブロックチェーンエンジニア、マイケル・パクの肖像"
+  "alt_michael": "リードブロックチェーンエンジニア、マイケル・パクの肖像",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -177,5 +177,8 @@
   "theme_switched": "{{mode}} 모드로 전환되었습니다",
   "alt_daniel": "CEO 겸 공동 창립자 Daniel Kim의 초상",
   "alt_emily": "CTO Emily Lee의 초상",
-  "alt_michael": "수석 블록체인 엔지니어 Michael Park의 초상"
+  "alt_michael": "수석 블록체인 엔지니어 Michael Park의 초상",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -177,5 +177,8 @@
   "theme_switched": "Mudou para o modo {{mode}}",
   "alt_daniel": "Retrato de Daniel Kim, CEO e cofundador",
   "alt_emily": "Retrato de Emily Lee, CTO",
-  "alt_michael": "Retrato de Michael Park, engenheiro líder de blockchain"
+  "alt_michael": "Retrato de Michael Park, engenheiro líder de blockchain",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -177,5 +177,8 @@
   "theme_switched": "Переключено в {{mode}} режим",
   "alt_daniel": "Портрет Дэниела Кима, CEO и соучредителя",
   "alt_emily": "Портрет Эмили Ли, CTO",
-  "alt_michael": "Портрет Майкла Парка, ведущего блокчейн-инженера"
+  "alt_michael": "Портрет Майкла Парка, ведущего блокчейн-инженера",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -177,5 +177,8 @@
   "theme_switched": "已切换到{{mode}}模式",
   "alt_daniel": "Daniel Kim 的肖像，首席执行官兼联合创始人",
   "alt_emily": "Emily Lee 的肖像，首席技术官",
-  "alt_michael": "Michael Park 的肖像，首席区块链工程师"
+  "alt_michael": "Michael Park 的肖像，首席区块链工程师",
+  "partner1_desc": "Blockchain platform for music rights and fan engagement",
+  "partner2_desc": "Gaming studio bringing play-to-earn experiences",
+  "partner3_desc": "Entertainment agency exploring decentralized media"
 }

--- a/partners.json
+++ b/partners.json
@@ -1,0 +1,26 @@
+[
+  {
+    "nameKey": "partner1",
+    "descKey": "partner1_desc",
+    "logo": "./assets/music-chain-logo.svg",
+    "alt": "MusicChain logo",
+    "icon": "music_note",
+    "url": "https://musicchain.example.com"
+  },
+  {
+    "nameKey": "partner2",
+    "descKey": "partner2_desc",
+    "logo": "./assets/game-world-logo.svg",
+    "alt": "GameWorld logo",
+    "icon": "sports_esports",
+    "url": "https://gameworld.example.com"
+  },
+  {
+    "nameKey": "partner3",
+    "descKey": "partner3_desc",
+    "logo": "./assets/entermedia-logo.svg",
+    "alt": "EnterMedia logo",
+    "icon": "movie",
+    "url": "https://entermedia.example.com"
+  }
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { initTheme } from './theme.ts';
 import { loadStakingStatus } from './staking.ts';
-import { initI18n, loadLanguage, translate, DEFAULT_LANG } from './i18n.ts';
+import {
+  initI18n,
+  loadLanguage,
+  translate,
+  DEFAULT_LANG,
+  currentLang,
+} from './i18n.ts';
 import { initNav } from './nav.ts';
 import { applyFancyTitles } from './fancy-title.ts';
 import { initAnimations, prefersReducedMotion } from './animations.ts';
@@ -47,6 +53,51 @@ if (backToTop) {
   });
 }
 
+async function loadPartners() {
+  const container = document.getElementById('partners-grid');
+  if (!container) return;
+  try {
+    await loadLanguage(currentLang);
+    const resp = await fetch('partners.json');
+    if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+    const partners = await resp.json();
+    partners.forEach((p) => {
+      const item = document.createElement('div');
+      item.className = 'logo-item';
+
+      const link = document.createElement('a');
+      link.href = p.url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+
+      const img = document.createElement('img');
+      img.src = p.logo;
+      img.alt = p.alt;
+      img.loading = 'lazy';
+
+      const icon = document.createElement('i');
+      icon.className = 'material-symbols-outlined';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = p.icon;
+
+      const name = document.createElement('span');
+      name.setAttribute('data-i18n', p.nameKey);
+      name.textContent = translate(p.nameKey);
+
+      const desc = document.createElement('p');
+      desc.setAttribute('data-i18n', p.descKey);
+      desc.textContent = translate(p.descKey);
+
+      link.append(img, icon, name, desc);
+      item.append(link);
+      container.append(item);
+    });
+  } catch (err) {
+    console.error('Failed to load partners:', err);
+  }
+}
+
 initTheme();
 initI18n();
 loadStakingStatus();
+loadPartners();


### PR DESCRIPTION
## Summary
- render partners from new `partners.json` with names, descriptions, and links
- hook up JSON-driven partners section and translation keys

## Testing
- `npm run build:web`
- `npm run lint`
- `npm run check-locales`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff0915e588327b7855caa90b5ac75