### PR TITLE
feat: wire newsletter form to backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,17 @@ Any web server (e.g., Nginx, Apache, GitHub Pages) can host the built site for p
 
 ## Configuration
 
+### Newsletter Signup
 
+The newsletter form posts to the URL defined by the `NEWSLETTER_API_URL` environment variable. Set this variable to your backend or third-party subscription endpoint (such as a Mailchimp form action) and ensure it is injected into the `data-endpoint` attribute of the `newsletter-form` in `index.html` during deployment.
+
+Example `.env`:
+
+```bash
+NEWSLETTER_API_URL=https://example.com/subscribe
+```
+
+Without this configuration, newsletter submissions will not reach the subscription service.
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/bundle.js
+++ b/bundle.js
@@ -1487,17 +1487,36 @@ var newsletterForm = document.querySelector(".newsletter-form");
 var newsletterMessage = document.querySelector(".newsletter-success");
 var newsletterTimeout;
 if (newsletterForm && newsletterMessage) {
+  const endpoint = newsletterForm.dataset.endpoint || window.NEWSLETTER_API_URL || "";
   newsletterForm.addEventListener("submit", async (e) => {
     e.preventDefault();
+    const emailInput = newsletterForm.querySelector(
+      'input[type="email"]'
+    );
+    if (!emailInput) return;
     const lang = localStorage.getItem("lang") || DEFAULT_LANG;
     const resolvedLang = await loadLanguage(lang) || DEFAULT_LANG;
-    newsletterMessage.textContent = translate(
-      "newsletter_success",
-      resolvedLang
-    );
+    try {
+      const resp = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: emailInput.value })
+      });
+      if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+      newsletterMessage.textContent = translate(
+        "newsletter_success",
+        resolvedLang
+      );
+    } catch (err) {
+      console.error("Newsletter subscription failed:", err);
+      newsletterMessage.textContent = translate(
+        "newsletter_error",
+        resolvedLang
+      );
+    }
     newsletterMessage.hidden = false;
     clearTimeout(newsletterTimeout);
-    newsletterTimeout = setTimeout(() => {
+    newsletterTimeout = window.setTimeout(() => {
       newsletterMessage.hidden = true;
       newsletterMessage.textContent = "";
     }, 5e3);

--- a/index.html
+++ b/index.html
@@ -716,7 +716,7 @@
         <p data-i18n="newsletter_text">
           최신 업데이트와 에어드롭 소식을 이메일로 받아보세요.
         </p>
-        <form class="newsletter-form">
+        <form class="newsletter-form" data-endpoint="">
           <input
             type="email"
             required

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -128,6 +128,7 @@
   "newsletter_button": "اشترك",
   "newsletter_placeholder": "عنوان البريد الإلكتروني",
   "newsletter_success": "شكرًا لاشتراكك!",
+  "newsletter_error": "فشل الاشتراك. يرجى المحاولة مرة أخرى.",
   "faq_title": "الأسئلة الشائعة",
   "faq_q1": "ما هو Hallyu Chain؟",
   "faq_a1": "Hallyu Chain هو أصل رقمي قائم على البلوكتشين لمجتمع K-POP.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -128,6 +128,7 @@
   "newsletter_button": "Abonnieren",
   "newsletter_placeholder": "E-Mail-Adresse",
   "newsletter_success": "Danke für deine Anmeldung!",
+  "newsletter_error": "Anmeldung fehlgeschlagen. Bitte versuche es erneut.",
   "faq_title": "Häufig gestellte Fragen",
   "faq_q1": "Was ist Hallyu Chain?",
   "faq_a1": "Hallyu Chain ist ein blockchainbasiertes digitales Asset für die K-POP-Community.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -128,6 +128,7 @@
   "newsletter_button": "Subscribe",
   "newsletter_placeholder": "Email address",
   "newsletter_success": "Thank you for subscribing!",
+  "newsletter_error": "Subscription failed. Please try again.",
   "faq_title": "Frequently Asked Questions",
   "faq_q1": "What is Hallyu Chain?",
   "faq_a1": "Hallyu Chain is a blockchain-based digital asset for the K-POP community.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -128,6 +128,7 @@
   "newsletter_button": "Suscribirse",
   "newsletter_placeholder": "Dirección de correo",
   "newsletter_success": "¡Gracias por suscribirte!",
+  "newsletter_error": "La suscripción falló. Inténtalo de nuevo.",
   "faq_title": "Preguntas frecuentes",
   "faq_q1": "¿Qué es Hallyu Chain?",
   "faq_a1": "Hallyu Chain es un activo digital basado en blockchain para la comunidad K-POP.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -128,6 +128,7 @@
   "newsletter_button": "S'abonner",
   "newsletter_placeholder": "Adresse e-mail",
   "newsletter_success": "Merci pour votre inscription !",
+  "newsletter_error": "L'inscription a échoué. Veuillez réessayer.",
   "faq_title": "Questions fréquentes",
   "faq_q1": "Qu'est-ce que Hallyu Chain ?",
   "faq_a1": "Hallyu Chain est un actif numérique basé sur la blockchain pour la communauté K-POP.",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -128,6 +128,7 @@
   "newsletter_button": "सदस्यता लें",
   "newsletter_placeholder": "ईमेल पता",
   "newsletter_success": "सदस्यता लेने के लिए धन्यवाद!",
+  "newsletter_error": "सदस्यता असफल रही। कृपया पुनः प्रयास करें।",
   "faq_title": "प्रश्नोत्तर",
   "faq_q1": "Hallyu Chain क्या है?",
   "faq_a1": "Hallyu Chain K-POP समुदाय के लिए ब्लॉकचेन आधारित डिजिटल संपत्ति है।",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -128,6 +128,7 @@
   "newsletter_button": "購読する",
   "newsletter_placeholder": "メールアドレス",
   "newsletter_success": "ご購読ありがとうございます！",
+  "newsletter_error": "購読に失敗しました。もう一度お試しください。",
   "faq_title": "よくある質問",
   "faq_q1": "Hallyu Chainとは？",
   "faq_a1": "Hallyu ChainはK-POPコミュニティ向けのブロックチェーンベースのデジタル資産です。",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -128,6 +128,7 @@
   "newsletter_button": "구독하기",
   "newsletter_placeholder": "이메일 주소",
   "newsletter_success": "구독해주셔서 감사합니다!",
+  "newsletter_error": "구독에 실패했습니다. 다시 시도해주세요.",
   "faq_title": "자주 묻는 질문",
   "faq_q1": "한류 체인은 무엇인가요?",
   "faq_a1": "한류 체인은 K-POP 커뮤니티를 위한 블록체인 기반 디지털 자산입니다.",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -128,6 +128,7 @@
   "newsletter_button": "Inscrever-se",
   "newsletter_placeholder": "Endereço de e-mail",
   "newsletter_success": "Obrigado por se inscrever!",
+  "newsletter_error": "A inscrição falhou. Tente novamente.",
   "faq_title": "Perguntas frequentes",
   "faq_q1": "O que é o Hallyu Chain?",
   "faq_a1": "Hallyu Chain é um ativo digital baseado em blockchain para a comunidade K-POP.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -128,6 +128,7 @@
   "newsletter_button": "Подписаться",
   "newsletter_placeholder": "Email-адрес",
   "newsletter_success": "Спасибо за подписку!",
+  "newsletter_error": "Не удалось подписаться. Попробуйте еще раз.",
   "faq_title": "Часто задаваемые вопросы",
   "faq_q1": "Что такое Hallyu Chain?",
   "faq_a1": "Hallyu Chain — это цифровой актив на базе блокчейна для сообщества K-POP.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -128,6 +128,7 @@
   "newsletter_button": "订阅",
   "newsletter_placeholder": "电子邮件地址",
   "newsletter_success": "感谢订阅！",
+  "newsletter_error": "订阅失败。请稍后再试。",
   "faq_title": "常见问题",
   "faq_q1": "Hallyu Chain 是什么？",
   "faq_a1": "Hallyu Chain 是面向 K-POP 社区的区块链数字资产。",


### PR DESCRIPTION
## Summary
- send newsletter form emails to configurable backend endpoint and show localized success or error messages
- add newsletter backend configuration docs

## Testing
- `npm run check-locales`
- `npm run lint`
- `npm test`
- `npm run build:web`

------
https://chatgpt.com/codex/tasks/task_e_68aff7eeb1988327b6c1dacabd2787e3