### PR TITLE
Clarify external asset links in resources section

### DIFF
--- a/index.html
+++ b/index.html
@@ -686,7 +686,20 @@
 
       <section id="resources">
         <h2 data-i18n="resources_title">참고 자료</h2>
-        <ul class="icon-list" id="resources-list"></ul>
+        <ul class="icon-list" id="resources-list">
+          <li>
+            <i class="material-symbols-outlined" aria-hidden="true">font_download</i>
+            <a href="./assets/hallyu-fonts.txt" target="_blank" rel="noopener noreferrer">
+              <span data-i18n="res_hallyu_fonts">Hallyu Fonts</span> (hosted externally)
+            </a>
+          </li>
+          <li>
+            <i class="material-symbols-outlined" aria-hidden="true">view_quilt</i>
+            <a href="./assets/layout-samples.txt" target="_blank" rel="noopener noreferrer">
+              <span data-i18n="res_layout_samples">Layout Samples</span> (hosted externally)
+            </a>
+          </li>
+        </ul>
       </section>
 
       <section id="staking">


### PR DESCRIPTION
## Summary
- Replace deprecated ZIP downloads with links to `.txt` placeholders in the Resources section
- Label resource download links to indicate they are hosted externally

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b00e52e30c83279b4f2f55fbcf1154