### PR TITLE
Add locale entries for external asset downloads

### DIFF
--- a/assets/logo-assets.txt
+++ b/assets/logo-assets.txt
@@ -1,0 +1,2 @@
+Logo assets for Hallyu Chain.
+Download: https://example.com/hallyu-logo.zip

--- a/index.html
+++ b/index.html
@@ -688,15 +688,21 @@
         <h2 data-i18n="resources_title">참고 자료</h2>
         <ul class="icon-list" id="resources-list">
           <li>
+            <i class="material-symbols-outlined" aria-hidden="true">image</i>
+            <a href="./assets/logo-assets.txt" target="_blank" rel="noopener noreferrer">
+              <span data-i18n="res_logo_assets">Logo Assets (hosted externally)</span>
+            </a>
+          </li>
+          <li>
             <i class="material-symbols-outlined" aria-hidden="true">font_download</i>
             <a href="./assets/hallyu-fonts.txt" target="_blank" rel="noopener noreferrer">
-              <span data-i18n="res_hallyu_fonts">Hallyu Fonts</span> (hosted externally)
+              <span data-i18n="res_hallyu_fonts">Hallyu Fonts (hosted externally)</span>
             </a>
           </li>
           <li>
             <i class="material-symbols-outlined" aria-hidden="true">view_quilt</i>
             <a href="./assets/layout-samples.txt" target="_blank" rel="noopener noreferrer">
-              <span data-i18n="res_layout_samples">Layout Samples</span> (hosted externally)
+              <span data-i18n="res_layout_samples">Layout Samples (hosted externally)</span>
             </a>
           </li>
         </ul>

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -194,6 +194,7 @@
   "faq_a6": "استخدم الجسر الرسمي عبر السلاسل لنقل الرموز من الشبكات الأخرى.",
   "faq_q7": "ما المكافآت التي يحصل عليها المكدّسون؟",
   "faq_a7": "يتلقى المكدّسون جزءًا من رسوم الشبكة والرموز الجديدة المُصدرة.",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -194,6 +194,7 @@
   "faq_a6": "Utilisez le pont officiel inter-chaînes pour déplacer des jetons depuis d'autres réseaux.",
   "faq_q7": "Quelles récompenses reçoivent les stakers ?",
   "faq_a7": "Les stakers reçoivent une part des frais du réseau et des nouveaux jetons émis.",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -194,6 +194,7 @@
   "faq_a6": "अन्य नेटवर्क से टोकन स्थानांतरित करने के लिए आधिकारिक क्रॉस-चेन ब्रिज का उपयोग करें।",
   "faq_q7": "स्टेकर्स को कौन से पुरस्कार मिलते हैं?",
   "faq_a7": "स्टेकर्स को नेटवर्क शुल्क और नए जारी टोकन का हिस्सा मिलता है।",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -194,6 +194,7 @@
   "faq_a6": "公式クロスチェーンブリッジを使用して他のネットワークからトークンを移動します。",
   "faq_q7": "ステーカーはどんな報酬を得られますか？",
   "faq_a7": "ステーカーはネットワーク手数料と新たに発行されたトークンの一部を受け取ります。",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -194,6 +194,7 @@
   "partner1_desc": "Blockchain platform for music rights and fan engagement",
   "partner2_desc": "Gaming studio bringing play-to-earn experiences",
   "partner3_desc": "Entertainment agency exploring decentralized media",
-  "res_hallyu_fonts": "Hallyu Fonts",
-  "res_layout_samples": "Layout Samples"
+  "res_logo_assets": "Logo Assets (hosted externally)",
+  "res_hallyu_fonts": "Hallyu Fonts (hosted externally)",
+  "res_layout_samples": "Layout Samples (hosted externally)"
 }

--- a/resources.json
+++ b/resources.json
@@ -35,6 +35,11 @@
     "url": "https://forum.hallyuchain.io"
   },
   {
+    "nameKey": "res_logo_assets",
+    "icon": "image",
+    "url": "./assets/logo-assets.txt"
+  },
+  {
     "nameKey": "res_hallyu_fonts",
     "icon": "font_download",
     "url": "./assets/hallyu-fonts.txt"


### PR DESCRIPTION
## Summary
- localize externally hosted logo, font, and layout download names across all locales
- list logo download alongside fonts and layout in resources
- track new placeholder link for logo assets

## Testing
- `npm run lint`
- `npm run check-locales`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00fc25d608327b5add9d7b4774441