### PR TITLE
Localize team bios across languages

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "رائد أعمال مخضرم في البلوكشين ومعجب بالكي‑بوب.",
+  "bio_emily": "مهندسة تبني أنظمة لامركزية قابلة للتوسّع.",
+  "bio_michael": "خبير في العقود الذكية وتصميم الشبكات.",
+  "bio_soojin": "خبيرة تسويق تربط المعجبين حول العالم.",
+  "bio_alex": "باني مجتمع يشجع التفاعل.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "Erfahrener Blockchain-Unternehmer und K-Pop-Fan.",
+  "bio_emily": "Ingenieurin, die skalierbare, dezentrale Systeme entwickelt.",
+  "bio_michael": "Experte für Smart Contracts und Netzwerktechnik.",
+  "bio_soojin": "Marketingstrategin, die Fans weltweit verbindet.",
+  "bio_alex": "Community-Builder, der Engagement fördert.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "Empresario veterano de blockchain y fan del K‑POP.",
+  "bio_emily": "Ingeniera que construye sistemas descentralizados escalables.",
+  "bio_michael": "Experto en contratos inteligentes y diseño de redes.",
+  "bio_soojin": "Estratega de marketing que conecta a los fans de todo el mundo.",
+  "bio_alex": "Constructor de comunidades que fomenta la participación.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "Entrepreneur chevronné de la blockchain et fan de K‑POP.",
+  "bio_emily": "Ingénieure qui développe des systèmes décentralisés évolutifs.",
+  "bio_michael": "Expert des contrats intelligents et de la conception réseau.",
+  "bio_soojin": "Stratège marketing reliant les fans du monde entier.",
+  "bio_alex": "Bâtisseur de communauté qui stimule l’engagement.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "अनुभवी ब्लॉकचेन उद्यमी और के‑पॉप प्रशंसक।",
+  "bio_emily": "स्केलेबल विकेन्द्रीकृत सिस्टम बनाने वाली इंजीनियर।",
+  "bio_michael": "स्मार्ट कॉन्ट्रैक्ट और नेटवर्क डिज़ाइन के विशेषज्ञ।",
+  "bio_soojin": "वैश्विक प्रशंसकों को जोड़ने वाली मार्केटिंग रणनीतिकार।",
+  "bio_alex": "सहभागिता को बढ़ावा देने वाला समुदाय निर्माता।",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "経験豊富なブロックチェーン起業家でありK-POPファン。",
+  "bio_emily": "スケーラブルな分散型システムを構築するエンジニア。",
+  "bio_michael": "スマートコントラクトとネットワーク設計のエキスパート。",
+  "bio_soojin": "世界中のファンをつなぐマーケティング戦略家。",
+  "bio_alex": "エンゲージメントを高めるコミュニティビルダー。",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "경험 많은 블록체인 기업가이자 K-POP 팬.",
+  "bio_emily": "확장 가능한 탈중앙화 시스템을 구축하는 엔지니어.",
+  "bio_michael": "스마트 계약과 네트워크 설계 전문가.",
+  "bio_soojin": "전 세계 팬을 잇는 마케팅 전략가.",
+  "bio_alex": "참여를 촉진하는 커뮤니티 빌더.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "Empreendedor experiente em blockchain e fã de K‑POP.",
+  "bio_emily": "Engenheira que constrói sistemas descentralizados escaláveis.",
+  "bio_michael": "Especialista em contratos inteligentes e design de redes.",
+  "bio_soojin": "Estrategista de marketing que conecta fãs do mundo todo.",
+  "bio_alex": "Construtor de comunidades que promove o engajamento.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "Опытный предприниматель в сфере блокчейна и поклонник K‑POP.",
+  "bio_emily": "Инженер, создающая масштабируемые децентрализованные системы.",
+  "bio_michael": "Эксперт по смарт‑контрактам и проектированию сетей.",
+  "bio_soojin": "Маркетинговый стратег, объединяющий фанатов по всему миру.",
+  "bio_alex": "Создатель сообщества, который стимулирует вовлечённость.",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -199,11 +199,11 @@
   "res_layout_samples": "Layout Samples (hosted externally)",
   "role_marketing": "Marketing Lead",
   "role_community": "Community Manager",
-  "bio_daniel": "Seasoned blockchain entrepreneur and K-POP fan.",
-  "bio_emily": "Engineer building scalable decentralized systems.",
-  "bio_michael": "Expert in smart contracts and network design.",
-  "bio_soojin": "Marketing strategist connecting global fans.",
-  "bio_alex": "Community builder fostering engagement.",
+  "bio_daniel": "资深的区块链企业家和K-POP粉丝。",
+  "bio_emily": "构建可扩展去中心化系统的工程师。",
+  "bio_michael": "智能合约和网络设计专家。",
+  "bio_soojin": "连接全球粉丝的营销策略师。",
+  "bio_alex": "促进参与的社区建设者。",
   "alt_soojin": "Portrait of Soo-jin Choi, Marketing Lead",
   "alt_alex": "Portrait of Alex Rivera, Community Manager"
 }


### PR DESCRIPTION
## Summary
- translate team bio strings into Arabic, German, Spanish, French, Hindi, Japanese, Korean, Portuguese, Russian, and Chinese

## Testing
- `npm run check-locales`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0185debe88327b817cbbc6d0c29d3