### PR TITLE
Inject newsletter endpoint from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,16 @@ Any web server (e.g., Nginx, Apache, GitHub Pages) can host the built site for p
 
 ### Newsletter Signup
 
-The newsletter form posts to the URL defined by the `NEWSLETTER_API_URL` environment variable. Set this variable to your backend or third-party subscription endpoint (such as a Mailchimp form action) and ensure it is injected into the `data-endpoint` attribute of the `newsletter-form` in `index.html` during deployment.
+Set `NEWSLETTER_API_URL` to the URL that should receive signup requests (your backend or a service like Mailchimp). During the build step, `npm run build:web` reads this environment variable and injects it into the `data-endpoint` attribute of the `.newsletter-form` in `index.html`.
 
-Example `.env`:
+Example deployment:
 
 ```bash
-NEWSLETTER_API_URL=https://example.com/subscribe
+export NEWSLETTER_API_URL=https://example.com/subscribe
+npm run build:web
 ```
 
-Without this configuration, newsletter submissions will not reach the subscription service.
+If the variable is unset, the build script leaves the form untouched and newsletter submissions will not reach any endpoint.
  
 ## Partners
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev:backend": "npx hardhat node",
     "dev": "npm run dev:backend & npm run dev:frontend",
     "serve": "npm run serve --workspace frontend",
-    "build:web": "esbuild src/index.ts --bundle --format=esm --outfile=bundle.js",
+    "build:web": "esbuild src/index.ts --bundle --format=esm --outfile=bundle.js && node scripts/inject-newsletter-endpoint.js",
     "test:frontend": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test src/*.test.js src/*.test.ts"
   },
   "keywords": [],

--- a/scripts/inject-newsletter-endpoint.js
+++ b/scripts/inject-newsletter-endpoint.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const filePath = path.join(__dirname, '..', 'index.html');
+const endpoint = process.env.NEWSLETTER_API_URL || '';
+
+if (!endpoint) {
+  console.warn('NEWSLETTER_API_URL is not set. Skipping newsletter endpoint injection.');
+  process.exit(0);
+}
+
+const html = fs.readFileSync(filePath, 'utf8');
+const dom = new JSDOM(html);
+const document = dom.window.document;
+const form = document.querySelector('.newsletter-form');
+
+if (!form) {
+  console.warn('newsletter-form not found in index.html.');
+  process.exit(0);
+}
+
+form.setAttribute('data-endpoint', endpoint);
+fs.writeFileSync(filePath, dom.serialize());
+console.log(`Injected newsletter endpoint: ${endpoint}`);


### PR DESCRIPTION
## Summary
- inject `NEWSLETTER_API_URL` into the `.newsletter-form` in `index.html` during build
- document newsletter signup configuration and example deployment steps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1131859c08327802ac53975a41fec