### PR TITLE
Add staking data fallback and document static strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ npm run test:frontend
 
 Both scripts support JavaScript and TypeScript test files.
 
+## Staking Data
+
+The frontend first attempts to load live staking information from `/api/staking`.
+If that request fails it automatically falls back to the static `staking.json`
+file in the project root. When using this fallback, remember to refresh the
+file's contents periodically or plan to replace it with a proper backend API so
+that staking figures do not become outdated.
+
 ## Local Development
 
 1. Clone the repository and change into the project directory:

--- a/bundle.js
+++ b/bundle.js
@@ -1208,7 +1208,7 @@ if (typeof window !== "undefined") {
 }
 
 // src/staking.ts
-async function fetchStakingData(fetchFn = fetch, url = "staking.json") {
+async function fetchStakingData(fetchFn = fetch, url = "/api/staking") {
   const resp = await fetchFn(url);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();
@@ -1219,24 +1219,33 @@ async function loadStakingStatus(fetchFn = fetch) {
   const errorEl = document.getElementById("staking-error");
   const percentEl = document.getElementById("staking-percent");
   const progressBar = document.getElementById("staking-progress-bar");
+  let data;
   try {
-    const data = await fetchStakingData(fetchFn);
-    if (total) total.textContent = data.totalStaked;
-    if (rewards) rewards.textContent = data.userRewards;
-    const percent = data.totalSupply ? Number(data.totalStaked) / Number(data.totalSupply) * 100 : Number(data.stakingPercent ?? 0);
-    if (percentEl) percentEl.textContent = `${percent.toFixed(2)}%`;
-    if (progressBar) progressBar.style.width = `${percent}%`;
+    data = await fetchStakingData(fetchFn);
   } catch (err) {
     console.error("Failed to fetch staking info", err);
-    if (total) total.textContent = translate("staking_unavailable");
-    if (rewards) rewards.textContent = translate("staking_unavailable");
-    if (percentEl) percentEl.textContent = translate("staking_unavailable");
-    if (progressBar) progressBar.style.width = "0%";
-    if (errorEl) {
-      errorEl.textContent = translate("staking_error_unavailable");
-      errorEl.hidden = false;
+    try {
+      const resp = await fetchFn("/staking.json");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      data = await resp.json();
+    } catch (fallbackErr) {
+      console.error("Failed to fetch fallback staking info", fallbackErr);
+      if (total) total.textContent = translate("staking_unavailable");
+      if (rewards) rewards.textContent = translate("staking_unavailable");
+      if (percentEl) percentEl.textContent = translate("staking_unavailable");
+      if (progressBar) progressBar.style.width = "0%";
+      if (errorEl) {
+        errorEl.textContent = translate("staking_error_unavailable");
+        errorEl.hidden = false;
+      }
+      return;
     }
   }
+  if (total) total.textContent = data.totalStaked;
+  if (rewards) rewards.textContent = data.userRewards;
+  const percent = data.totalSupply ? Number(data.totalStaked) / Number(data.totalSupply) * 100 : Number(data.stakingPercent ?? 0);
+  if (percentEl) percentEl.textContent = `${percent.toFixed(2)}%`;
+  if (progressBar) progressBar.style.width = `${percent}%`;
 }
 
 // src/nav.ts

--- a/src/staking.test.ts
+++ b/src/staking.test.ts
@@ -23,7 +23,24 @@ test('loadStakingStatus populates elements', async () => {
   assert.equal(document.getElementById('staking-progress-bar').style.width, '50%');
 });
 
-test('loadStakingStatus shows error on failure', async () => {
+test('loadStakingStatus falls back to staking.json', async () => {
+  global.fetch = async (url) => {
+    if (url === '/api/staking') return { ok: false, status: 500 };
+    return {
+      ok: true,
+      json: async () => ({ totalStaked: '50', userRewards: '2', totalSupply: '100' }),
+    };
+  };
+  await loadStakingStatus();
+  assert.equal(document.getElementById('total-staked').textContent, '50');
+  assert.equal(document.getElementById('user-rewards').textContent, '2');
+  assert.equal(document.getElementById('staking-percent').textContent, '50.00%');
+  assert.equal(document.getElementById('staking-progress-bar').style.width, '50%');
+  const err = document.getElementById('staking-error');
+  assert.equal(err.hidden, true);
+});
+
+test('loadStakingStatus shows error when both API and fallback fail', async () => {
   global.fetch = async () => ({ ok: false, status: 500 });
   await loadStakingStatus();
   assert.equal(document.getElementById('total-staked').textContent, 'N/A');

--- a/src/staking.ts
+++ b/src/staking.ts
@@ -13,25 +13,34 @@ export async function loadStakingStatus(fetchFn = fetch) {
   const errorEl = document.getElementById('staking-error');
   const percentEl = document.getElementById('staking-percent');
   const progressBar = document.getElementById('staking-progress-bar');
+  let data;
   try {
-    const data = await fetchStakingData(fetchFn);
-    if (total) total.textContent = data.totalStaked;
-    if (rewards) rewards.textContent = data.userRewards;
-    const percent =
-      data.totalSupply
-        ? (Number(data.totalStaked) / Number(data.totalSupply)) * 100
-        : Number(data.stakingPercent ?? 0);
-    if (percentEl) percentEl.textContent = `${percent.toFixed(2)}%`;
-    if (progressBar) progressBar.style.width = `${percent}%`;
+    data = await fetchStakingData(fetchFn);
   } catch (err) {
     console.error('Failed to fetch staking info', err);
-    if (total) total.textContent = translate('staking_unavailable');
-    if (rewards) rewards.textContent = translate('staking_unavailable');
-    if (percentEl) percentEl.textContent = translate('staking_unavailable');
-    if (progressBar) progressBar.style.width = '0%';
-    if (errorEl) {
-      errorEl.textContent = translate('staking_error_unavailable');
-      errorEl.hidden = false;
+    try {
+      const resp = await fetchFn('/staking.json');
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      data = await resp.json();
+    } catch (fallbackErr) {
+      console.error('Failed to fetch fallback staking info', fallbackErr);
+      if (total) total.textContent = translate('staking_unavailable');
+      if (rewards) rewards.textContent = translate('staking_unavailable');
+      if (percentEl) percentEl.textContent = translate('staking_unavailable');
+      if (progressBar) progressBar.style.width = '0%';
+      if (errorEl) {
+        errorEl.textContent = translate('staking_error_unavailable');
+        errorEl.hidden = false;
+      }
+      return;
     }
   }
+  if (total) total.textContent = data.totalStaked;
+  if (rewards) rewards.textContent = data.userRewards;
+  const percent =
+    data.totalSupply
+      ? (Number(data.totalStaked) / Number(data.totalSupply)) * 100
+      : Number(data.stakingPercent ?? 0);
+  if (percentEl) percentEl.textContent = `${percent.toFixed(2)}%`;
+  if (progressBar) progressBar.style.width = `${percent}%`;
 }


### PR DESCRIPTION
## Summary
- use `staking.json` when `/api/staking` is unavailable
- document the fallback and the need to refresh static staking data
- test fallback and failure scenarios and rebuild bundle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1381a74948327b2ab45a755b27334