### PR TITLE
Document and configure newsletter signup endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 artifacts/
 cache/
 whitepaper/whitepaper.pdf
+newsletter.config.json

--- a/README.md
+++ b/README.md
@@ -216,7 +216,10 @@ Any web server (e.g., Nginx, Apache, GitHub Pages) can host the built site for p
 
 ### Newsletter Signup
 
-Set `NEWSLETTER_API_URL` to the URL that should receive signup requests (your backend or a service like Mailchimp). During the build step, `npm run build:web` reads this environment variable and injects it into the `data-endpoint` attribute of the `.newsletter-form` in `index.html`.
+Set the newsletter signup endpoint using either an environment variable or a config file.
+
+- **Environment variable:** Define `NEWSLETTER_API_URL` with the URL that should receive signup requests (your backend or a service like Mailchimp). During the build step, `npm run build:web` reads this variable and injects it into the `data-endpoint` attribute of the `.newsletter-form` in `index.html`.
+- **Config file:** Copy `newsletter.config.example.json` to `newsletter.config.json` and edit `newsletterApiUrl` to your endpoint. This file is used when `NEWSLETTER_API_URL` is not set.
 
 Example deployment:
 
@@ -225,7 +228,7 @@ export NEWSLETTER_API_URL=https://example.com/subscribe
 npm run build:web
 ```
 
-If the variable is unset, the build script leaves the form untouched and newsletter submissions will not reach any endpoint.
+If neither the environment variable nor the config file provides an endpoint, the build script leaves the form untouched and newsletter submissions will not reach any endpoint.
  
 ## Partners
 
@@ -237,7 +240,7 @@ Collects useful links for community members and developers. The list of resource
 
 ## Newsletter
 
-Handles email subscriptions for updates and airdrop news. The signup form in `index.html` and logic in `src/index.ts` post to the endpoint specified by the `NEWSLETTER_API_URL` environment variable. Translations reside under `locales/`.
+Handles email subscriptions for updates and airdrop news. The signup form in `index.html` and logic in `src/index.ts` post to the endpoint provided either by the `NEWSLETTER_API_URL` environment variable or by `newsletter.config.json`. Translations reside under `locales/`.
 
 ## FAQ
 

--- a/index.html
+++ b/index.html
@@ -719,7 +719,7 @@
         <p data-i18n="newsletter_text">
           최신 업데이트와 에어드롭 소식을 이메일로 받아보세요.
         </p>
-        <form class="newsletter-form" data-endpoint="">
+        <form class="newsletter-form" data-endpoint="https://example.com/subscribe">
           <input
             type="email"
             required

--- a/newsletter.config.example.json
+++ b/newsletter.config.example.json
@@ -1,0 +1,3 @@
+{
+  "newsletterApiUrl": "https://example.com/subscribe"
+}

--- a/scripts/inject-newsletter-endpoint.js
+++ b/scripts/inject-newsletter-endpoint.js
@@ -3,10 +3,24 @@ const path = require('path');
 const { JSDOM } = require('jsdom');
 
 const filePath = path.join(__dirname, '..', 'index.html');
-const endpoint = process.env.NEWSLETTER_API_URL || '';
+const configPath = path.join(__dirname, '..', 'newsletter.config.json');
+
+let endpoint = process.env.NEWSLETTER_API_URL || '';
+
+// Fall back to config file if environment variable is not set
+if (!endpoint && fs.existsSync(configPath)) {
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    endpoint = config.newsletterApiUrl || config.endpoint || '';
+  } catch (err) {
+    console.warn('Failed to parse newsletter.config.json:', err);
+  }
+}
 
 if (!endpoint) {
-  console.warn('NEWSLETTER_API_URL is not set. Skipping newsletter endpoint injection.');
+  console.warn(
+    'Newsletter endpoint not set. Skipping newsletter endpoint injection.'
+  );
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- Add example endpoint to newsletter form
- Allow injection script to read endpoint from `NEWSLETTER_API_URL` or `newsletter.config.json`
- Document configuration options and add sample config file

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b13a81380c83279bc0e285d94224d3