### PR TITLE
Enable tokenomics on standalone whitepaper pages

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -190,7 +190,15 @@ export async function initI18n() {
   }
 }
 
-// Expose translate helper
+// Expose helpers for standalone pages
+declare global {
+  interface Window {
+    translate?: typeof translate;
+    applyTokenomics?: typeof applyTokenomics;
+  }
+}
+
 if (typeof window !== 'undefined') {
   window.translate = translate;
+  window.applyTokenomics = applyTokenomics;
 }

--- a/whitepaper/ar/index.html
+++ b/whitepaper/ar/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">مجتمع Discord</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/de/index.html
+++ b/whitepaper/de/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord-Community</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/en/index.html
+++ b/whitepaper/en/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord Community</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/es/index.html
+++ b/whitepaper/es/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Comunidad de Discord</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/fr/index.html
+++ b/whitepaper/fr/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Communauté Discord</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/hi/index.html
+++ b/whitepaper/hi/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord समुदाय</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/ja/index.html
+++ b/whitepaper/ja/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord コミュニティ</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/ko/index.html
+++ b/whitepaper/ko/index.html
@@ -79,3 +79,9 @@
     <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord 커뮤니티</a></li>
   </ul>
 </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/pt/index.html
+++ b/whitepaper/pt/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Comunidade Discord</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/ru/index.html
+++ b/whitepaper/ru/index.html
@@ -79,3 +79,9 @@
           <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Сообщество Discord</a></li>
         </ul>
       </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>

--- a/whitepaper/zh/index.html
+++ b/whitepaper/zh/index.html
@@ -79,3 +79,9 @@
             <li><i class="material-symbols-outlined">chat</i><a href="https://discord.gg/example" target="_blank" rel="noopener noreferrer">Discord 社区</a></li>
           </ul>
         </section>
+<script type="module">
+  import '../../bundle.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    window.applyTokenomics?.();
+  });
+</script>


### PR DESCRIPTION
## Summary
- expose `applyTokenomics` globally for direct page use
- import site bundle and invoke tokenomics replacement in each whitepaper page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b13e14dd4483279ac46bb2f6d418c9