### PR TITLE
Move frontend logic to plain JS modules

### DIFF
--- a/app/animations.js
+++ b/app/animations.js
@@ -1,0 +1,95 @@
+let gsap;
+let ScrollTrigger;
+let hasGSAP = false;
+
+if (
+  typeof window !== 'undefined' &&
+  window.gsap &&
+  window.ScrollTrigger
+) {
+  gsap = window.gsap;
+  ScrollTrigger = window.ScrollTrigger;
+  gsap.registerPlugin(ScrollTrigger);
+  hasGSAP = true;
+}
+
+const reduceMotionQuery =
+  typeof window !== 'undefined' && window.matchMedia
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : {
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      };
+export let prefersReducedMotion = reduceMotionQuery.matches;
+
+function applyAnimations() {
+  // Remove any existing ScrollTriggers to avoid duplicates
+  ScrollTrigger.getAll().forEach((t) => t.kill());
+
+  const sections = document.querySelectorAll(
+    'section, .wp-section'
+  );
+  if (!prefersReducedMotion) {
+    sections.forEach((section) => {
+      // Clear inline styles that may have been set when motion was reduced
+      section.style.opacity = '';
+      section.style.transform = '';
+      gsap.from(section, {
+        opacity: 0,
+        y: 40,
+        duration: 1,
+        scrollTrigger: {
+          trigger: section,
+          start: 'top 80%',
+        },
+      });
+    });
+  } else {
+    // Make sure sections remain visible without animation
+    sections.forEach((section) => {
+      section.style.opacity = 1;
+      section.style.transform = 'none';
+    });
+  }
+}
+
+function initHeroAnimation() {
+  const hero = document.querySelector('.hero');
+  const fancy = document.querySelector('.hero-title');
+  // Disable fancy hero animation if reduced motion is requested
+  if (hero && fancy && !prefersReducedMotion) {
+    hero.addEventListener('mousemove', (e) => {
+      const rect = hero.getBoundingClientRect();
+      const x = (e.clientX - rect.left) / rect.width - 0.5;
+      const y = (e.clientY - rect.top) / rect.height - 0.5;
+      gsap.to(fancy, {
+        rotationY: x * 30,
+        rotationX: -y * 30,
+        ease: 'power2.out',
+      });
+    });
+    hero.addEventListener('mouseleave', () => {
+      gsap.to(fancy, {
+        rotationY: 0,
+        rotationX: 0,
+        duration: 0.5,
+        ease: 'power2.out',
+      });
+    });
+  }
+}
+
+export function initAnimations() {
+  if (!hasGSAP) {
+    console.warn('GSAP or ScrollTrigger not found. Animations disabled.');
+    return;
+  }
+  applyAnimations();
+  initHeroAnimation();
+  reduceMotionQuery.addEventListener('change', (event) => {
+    prefersReducedMotion = event.matches;
+    applyAnimations();
+    initHeroAnimation();
+  });
+}

--- a/app/fancy-title.js
+++ b/app/fancy-title.js
@@ -1,0 +1,122 @@
+class HCFancyTitle extends HTMLElement {
+  static get observedAttributes() {
+    return ['text', 'size'];
+  }
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.prefersReducedMotion = null;
+    this.handlePreferenceChange = null;
+  }
+  connectedCallback() {
+    if (typeof window !== 'undefined' && 'matchMedia' in window) {
+      this.prefersReducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      );
+      this.handlePreferenceChange = () => this.render();
+      const mql = this.prefersReducedMotion;
+      if (mql.addEventListener) {
+        mql.addEventListener('change', this.handlePreferenceChange);
+      } else {
+        mql.addListener(this.handlePreferenceChange);
+      }
+    }
+    this.render();
+  }
+  attributeChangedCallback() {
+    this.render();
+  }
+  disconnectedCallback() {
+    const mql = this.prefersReducedMotion;
+    const handler = this.handlePreferenceChange;
+    if (mql && handler) {
+      if (mql.removeEventListener) {
+        mql.removeEventListener('change', handler);
+      } else {
+        mql.removeListener(handler);
+      }
+    }
+  }
+  render() {
+    const text = this.getAttribute('text') || '';
+    const size = this.getAttribute('size') || 'large';
+    const root = this.shadowRoot;
+    if (!root) return;
+
+    while (root.firstChild) {
+      root.removeChild(root.firstChild);
+    }
+
+    const prefersReduced = this.prefersReducedMotion?.matches ?? false;
+    const style = document.createElement('style');
+    style.textContent = `
+        :host { display: inline-block; }
+        h1 {
+          font-family: 'Poppins', sans-serif;
+          font-size: ${size === 'medium' ? '1.8rem' : 'clamp(2.5rem, 8vw, 4rem)'};
+          margin: 0;
+          position: relative;
+          background: linear-gradient(45deg,#ff0080,#ffcd00,#00f0ff);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+        }
+        h1::before, h1::after {
+          content: attr(data-text);
+          position: absolute;
+          top: 0; left: 0;
+          width: 100%; height: 100%;
+          mix-blend-mode: screen;
+          animation: ${prefersReduced ? 'none' : 'glitch 2s infinite'};
+        }
+        h1::before { color: #f0f; clip-path: polygon(0 0,100% 0,100% 45%,0 45%); }
+        h1::after { color: #0ff; clip-path: polygon(0 55%,100% 55%,100% 100%,0 100%); }
+        ${
+          prefersReduced
+            ? ''
+            : `@keyframes glitch {
+          0% { transform: translate(0); }
+          20% { transform: translate(-2px,-2px); }
+          40% { transform: translate(2px,2px); }
+          60% { transform: translate(-2px,2px); }
+          80% { transform: translate(2px,-2px); }
+          100% { transform: translate(0); }
+        }`
+        }
+    `;
+    root.appendChild(style);
+
+    this.setAttribute('role', 'heading');
+    this.setAttribute('aria-level', size === 'medium' ? '2' : '1');
+
+    const h1 = document.createElement('h1');
+    h1.textContent = text;
+    h1.setAttribute('data-text', text);
+    root.appendChild(h1);
+  }
+}
+
+customElements.define('hc-fancy-title', HCFancyTitle);
+
+export function applyFancyTitles() {
+  document.querySelectorAll('h1').forEach((h1) => {
+    if (h1.closest('hc-fancy-title')) return;
+    const fancy = document.createElement('hc-fancy-title');
+    fancy.setAttribute('size', 'large');
+    fancy.setAttribute('text', h1.textContent.trim());
+    if (h1.className) fancy.className = h1.className;
+    if (h1.dataset.i18n) fancy.setAttribute('data-i18n', h1.dataset.i18n);
+    h1.replaceWith(fancy);
+  });
+  document.querySelectorAll('h2').forEach((h2) => {
+    if (h2.closest('hc-fancy-title')) return;
+    const fancy = document.createElement('hc-fancy-title');
+    fancy.setAttribute('size', 'medium');
+    fancy.setAttribute('text', h2.textContent.trim());
+    if (h2.className) fancy.className = h2.className;
+    if (h2.id) fancy.id = h2.id;
+    if (h2.dataset.i18n) fancy.setAttribute('data-i18n', h2.dataset.i18n);
+    h2.replaceWith(fancy);
+  });
+}
+
+window.applyFancyTitles = applyFancyTitles;

--- a/app/i18n.js
+++ b/app/i18n.js
@@ -1,0 +1,192 @@
+import { showNotice } from './notice.js';
+import createDOMPurify from 'dompurify';
+const DOMPurify = createDOMPurify(window);
+
+export const translations = {};
+export const DEFAULT_LANG = 'en';
+const FALLBACK_NOTICES = {
+  notice_load_fail: 'Localization failed to load.',
+  notice_lang_unavailable:
+    'Selected language unavailable. Using default language.',
+};
+let tokenomicsCache = null;
+
+export let currentLang = localStorage.getItem('lang') || DEFAULT_LANG;
+
+async function loadTokenomics() {
+  if (!tokenomicsCache) {
+    const resp = await fetch('tokenomics.json');
+    if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+    tokenomicsCache = await resp.json();
+  }
+  return tokenomicsCache;
+}
+
+function replaceTokenomicsPlaceholders(root, data) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+  while (walker.nextNode()) {
+    walker.currentNode.textContent = walker.currentNode.textContent.replace(
+      /\{(supply|dao|community|team|advisors|investors|burn)\}/g,
+      (_, key) => {
+        const value = data[key];
+        if (value === undefined) return '';
+        return key === 'supply'
+          ? Number(value).toLocaleString()
+          : String(value);
+      }
+    );
+  }
+}
+
+export async function applyTokenomics(root = document) {
+  try {
+    const data = await loadTokenomics();
+    replaceTokenomicsPlaceholders(root, data);
+  } catch (err) {
+    console.error('Failed to load tokenomics:', err);
+  }
+}
+
+export async function loadLanguage(lang) {
+  if (!translations[lang]) {
+    try {
+      const response = await fetch(`locales/${lang}.json`);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      translations[lang] = await response.json();
+    } catch (err) {
+      console.error(`Failed to load language '${lang}':`, err);
+      if (lang !== DEFAULT_LANG) {
+        return await loadLanguage(DEFAULT_LANG);
+      }
+      return null;
+    }
+  }
+  return lang;
+}
+
+export function translate(key, lang = currentLang) {
+  return (
+    translations[lang]?.[key] ||
+    translations[DEFAULT_LANG]?.[key] ||
+    FALLBACK_NOTICES[key] ||
+    key
+  );
+}
+
+export async function setLanguage(lang) {
+  const loadedLang = await loadLanguage(lang);
+  if (!loadedLang) {
+    showNotice(translate('notice_load_fail', DEFAULT_LANG));
+    return;
+  }
+  if (loadedLang !== lang) {
+    showNotice(translate('notice_lang_unavailable', loadedLang));
+  }
+  lang = loadedLang;
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+  document.documentElement.lang = lang;
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    const text = translations[lang][key];
+    if (text) {
+      if (el.tagName === 'HC-FANCY-TITLE') {
+        el.setAttribute('text', text);
+      } else {
+        el.textContent = text;
+      }
+    }
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-placeholder');
+    const text = translations[lang][key];
+    if (text) {
+      el.setAttribute('placeholder', text);
+    }
+  });
+  document.querySelectorAll('[data-i18n-alt]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-alt');
+    const text = translations[lang][key];
+    if (text) {
+      el.setAttribute('alt', text);
+    }
+  });
+  document.querySelectorAll('[data-i18n-aria-label]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-aria-label');
+    const text = translations[lang][key];
+    if (text) {
+      el.setAttribute('aria-label', text);
+    }
+  });
+  document.querySelectorAll('[data-i18n-meta]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-meta');
+    const text = translations[lang][key];
+    if (text) {
+      el.setAttribute('content', text);
+    }
+  });
+  if (location.hash === '#whitepaper') {
+    const wpSelect = document.getElementById('whitepaper-lang');
+    const wpLang = wpSelect?.value || lang;
+    await loadWhitepaper(wpLang);
+  }
+  await applyTokenomics();
+  const page = document.body.dataset.page;
+  const titleKey = `title_${page}`;
+  if (translations[lang][titleKey]) {
+    document.title = translations[lang][titleKey];
+  }
+  const select = document.querySelector('.lang-select');
+  if (select) select.value = lang;
+}
+
+export async function loadWhitepaper(lang) {
+  const container = document.getElementById('whitepaper-content');
+  if (!container) return;
+  try {
+    const resp = await fetch(`whitepaper/${lang}/index.html`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const html = await resp.text();
+    container.innerHTML = DOMPurify.sanitize(html);
+    await applyTokenomics(container);
+    window.applyFancyTitles?.();
+  } catch (err) {
+    console.error('Failed to load whitepaper:', err);
+    const fallback = `<p>${translate('notice_whitepaper_unavailable', lang)}</p>`;
+    container.innerHTML = DOMPurify.sanitize(fallback);
+  }
+}
+
+function handleHash() {
+  if (location.hash === '#whitepaper') {
+    const wpSelect = document.getElementById('whitepaper-lang');
+    const wpLang =
+      wpSelect?.value || localStorage.getItem('lang') || currentLang;
+    loadWhitepaper(wpLang);
+  }
+}
+
+export async function initI18n() {
+  try {
+    await setLanguage(currentLang);
+  } catch (err) {
+    console.error('Failed to initialize i18n:', err);
+  }
+  window.addEventListener('hashchange', handleHash);
+  handleHash();
+  const select = document.querySelector('.lang-select');
+  if (select) {
+    select.addEventListener('change', (e) => setLanguage(e.target.value));
+  }
+  const wpSelect = document.getElementById('whitepaper-lang');
+  if (wpSelect) {
+    wpSelect.addEventListener('change', (e) =>
+      loadWhitepaper(e.target.value)
+    );
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.translate = translate;
+  window.applyTokenomics = applyTokenomics;
+}

--- a/app/main.js
+++ b/app/main.js
@@ -1,0 +1,229 @@
+import { initTheme } from './theme.js';
+import { loadStakingStatus } from './staking.js';
+import {
+  initI18n,
+  loadLanguage,
+  translate,
+  DEFAULT_LANG,
+  currentLang,
+} from './i18n.js';
+import { initNav } from './nav.js';
+import { applyFancyTitles } from './fancy-title.js';
+import { initAnimations, prefersReducedMotion } from './animations.js';
+
+applyFancyTitles();
+initNav();
+initAnimations();
+
+const newsletterForm = document.querySelector('.newsletter-form');
+const newsletterMessage = document.querySelector(
+  '.newsletter-success'
+);
+let newsletterTimeout;
+
+if (newsletterForm && newsletterMessage) {
+  const endpoint =
+    newsletterForm.dataset.endpoint || window.NEWSLETTER_API_URL || '';
+  newsletterForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const emailInput = newsletterForm.querySelector(
+      'input[type="email"]'
+    );
+    if (!emailInput) return;
+
+    const lang = localStorage.getItem('lang') || DEFAULT_LANG;
+    // Load the selected language and use the resolved value to handle fallbacks
+    const resolvedLang = (await loadLanguage(lang)) || DEFAULT_LANG;
+    try {
+      const resp = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: emailInput.value }),
+      });
+      if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+      newsletterMessage.textContent = translate(
+        'newsletter_success',
+        resolvedLang
+      );
+    } catch (err) {
+      console.error('Newsletter subscription failed:', err);
+      newsletterMessage.textContent = translate(
+        'newsletter_error',
+        resolvedLang
+      );
+    }
+    newsletterMessage.hidden = false;
+    clearTimeout(newsletterTimeout);
+    newsletterTimeout = window.setTimeout(() => {
+      newsletterMessage.hidden = true;
+      newsletterMessage.textContent = '';
+    }, 5000);
+    newsletterForm.reset();
+  });
+}
+
+const backToTop = document.querySelector('.back-to-top');
+if (backToTop) {
+  window.addEventListener('scroll', () => {
+    backToTop.classList.toggle('visible', window.scrollY > 400);
+  });
+  // Respect reduced motion setting for scroll behavior
+  backToTop.addEventListener('click', () => {
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+    });
+  });
+}
+
+async function loadPartners() {
+  const container = document.getElementById('partners-grid');
+  if (!container) return;
+  try {
+    await loadLanguage(currentLang);
+    const resp = await fetch('partners.json');
+    if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+    const partners = await resp.json();
+    partners.forEach((p) => {
+      const item = document.createElement('div');
+      item.className = 'logo-item';
+
+      const link = document.createElement('a');
+      link.href = p.url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+
+      const img = document.createElement('img');
+      img.src = p.logo;
+      img.alt = p.alt;
+      img.loading = 'lazy';
+
+      const icon = document.createElement('i');
+      icon.className = 'material-symbols-outlined';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = p.icon;
+
+      const name = document.createElement('span');
+      name.setAttribute('data-i18n', p.nameKey);
+      name.textContent = translate(p.nameKey);
+
+      const desc = document.createElement('p');
+      desc.setAttribute('data-i18n', p.descKey);
+      desc.textContent = translate(p.descKey);
+
+      link.append(img, icon, name, desc);
+      item.append(link);
+      container.append(item);
+    });
+  } catch (err) {
+    console.error('Failed to load partners:', err);
+  }
+}
+
+async function loadResources() {
+  const list = document.getElementById('resources-list');
+  if (!list) return;
+  list.innerHTML = '';
+  try {
+    await loadLanguage(currentLang);
+    const [resResp, addrResp] = await Promise.all([
+      fetch('resources.json'),
+      fetch('token-address.json'),
+    ]);
+    if (!resResp.ok) throw new Error(`HTTP error ${resResp.status}`);
+    const resources = await resResp.json();
+    if (addrResp.ok) {
+      const addresses = await addrResp.json();
+      if (addresses.mainnet?.HallyuToken) {
+        resources.push({
+          nameKey: 'res_token_mainnet',
+          icon: 'token',
+          url: `https://etherscan.io/token/${addresses.mainnet.HallyuToken}`,
+        });
+      }
+      if (addresses.testnet?.HallyuToken) {
+        resources.push({
+          nameKey: 'res_token_testnet',
+          icon: 'token',
+          url: `https://sepolia.etherscan.io/token/${addresses.testnet.HallyuToken}`,
+        });
+      }
+    }
+    resources.forEach((r) => {
+      const li = document.createElement('li');
+
+      const icon = document.createElement('i');
+      icon.className = 'material-symbols-outlined';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = r.icon;
+
+      const link = document.createElement('a');
+      link.href = r.url;
+      if (r.url.startsWith('http')) {
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+      }
+
+      const label = document.createElement('span');
+      label.setAttribute('data-i18n', r.nameKey);
+      label.textContent = translate(r.nameKey);
+
+      link.append(label);
+      li.append(icon, link);
+      list.append(li);
+    });
+  } catch (err) {
+    console.error('Failed to load resources:', err);
+  }
+}
+
+async function loadTeam() {
+  const grid = document.getElementById('team-grid');
+  if (!grid) return;
+  try {
+    await loadLanguage(currentLang);
+    const resp = await fetch('team.json');
+    if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
+    const team = await resp.json();
+    team.forEach((m) => {
+      const member = document.createElement('div');
+      member.className = 'member';
+
+      const link = document.createElement('a');
+      link.href = m.link;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+
+      const img = document.createElement('img');
+      img.src = m.image;
+      img.alt = translate(m.altKey);
+      img.loading = 'lazy';
+      img.setAttribute('data-i18n-alt', m.altKey);
+
+      const name = document.createElement('h3');
+      name.textContent = m.name;
+
+      link.append(img, name);
+
+      const role = document.createElement('p');
+      role.setAttribute('data-i18n', m.roleKey);
+      role.textContent = translate(m.roleKey);
+
+      const bio = document.createElement('p');
+      bio.setAttribute('data-i18n', m.bioKey);
+      bio.textContent = translate(m.bioKey);
+
+      member.append(link, role, bio);
+      grid.append(member);
+    });
+  } catch (err) {
+    console.error('Failed to load team:', err);
+  }
+}
+
+initTheme();
+initI18n();
+loadStakingStatus();
+loadPartners();
+loadResources();
+loadTeam();

--- a/app/nav.js
+++ b/app/nav.js
@@ -1,0 +1,64 @@
+export function initNav() {
+  function updateNavHeight() {
+    const navbar = document.querySelector('.navbar');
+    if (!navbar) return;
+    const height = navbar.getBoundingClientRect().height;
+    const { position } = window.getComputedStyle(navbar);
+    const fixed = position === 'fixed' || window.innerWidth > 768;
+    const value = fixed ? `${height}px` : '0px';
+    document.documentElement.style.setProperty('--nav-height', value);
+    document.documentElement.style.scrollPaddingTop = value;
+    document.body.style.paddingTop = value;
+  }
+
+  updateNavHeight();
+  window.addEventListener('resize', updateNavHeight);
+
+  const menuToggle = document.querySelector('.menu-toggle');
+  const navLinks = document.getElementById('primary-navigation');
+  if (navLinks) navLinks.setAttribute('aria-hidden', 'true');
+  if (menuToggle && navLinks) {
+    menuToggle.addEventListener('click', () => {
+      const navbar = document.querySelector('.navbar');
+      const open = navbar.classList.toggle('open');
+      menuToggle.setAttribute('aria-expanded', open);
+      navLinks.setAttribute('aria-hidden', open ? 'false' : 'true');
+      if (open) {
+        const firstLink = navLinks.querySelector('a');
+        if (firstLink) firstLink.focus();
+      }
+    });
+    navLinks.addEventListener('click', (e) => {
+      if (e.target.closest('a')) {
+        const navbar = document.querySelector('.navbar');
+        navbar.classList.remove('open');
+        menuToggle.setAttribute('aria-expanded', 'false');
+        navLinks.setAttribute('aria-hidden', 'true');
+      }
+    });
+    navLinks.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+      const navbar = document.querySelector('.navbar');
+      if (!navbar.classList.contains('open')) return;
+      const links = navLinks.querySelectorAll('a');
+      const firstLink = links[0];
+      const lastLink = links[links.length - 1];
+      if (!e.shiftKey && document.activeElement === lastLink) {
+        e.preventDefault();
+        firstLink.focus();
+      } else if (e.shiftKey && document.activeElement === firstLink) {
+        e.preventDefault();
+        lastLink.focus();
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    const navbar = document.querySelector('.navbar');
+    if (!navbar.classList.contains('open')) return;
+    navbar.classList.remove('open');
+    if (menuToggle) menuToggle.setAttribute('aria-expanded', 'false');
+    if (navLinks) navLinks.setAttribute('aria-hidden', 'true');
+  });
+}

--- a/app/notice.js
+++ b/app/notice.js
@@ -1,0 +1,19 @@
+const notice = document.createElement('div');
+notice.className = 'notice';
+notice.setAttribute('role', 'status');
+notice.setAttribute('aria-live', 'polite');
+notice.hidden = true;
+document.body.appendChild(notice);
+let noticeTimeout;
+export function showNotice(message, delay = 4000) {
+  notice.textContent = message;
+  notice.hidden = false;
+  clearTimeout(noticeTimeout);
+  noticeTimeout = setTimeout(() => {
+    notice.hidden = true;
+    notice.textContent = '';
+  }, delay);
+}
+if (typeof window !== 'undefined') {
+  window.showNotice = showNotice;
+}

--- a/app/staking.js
+++ b/app/staking.js
@@ -1,0 +1,46 @@
+import { translate } from './i18n.js';
+
+// Default endpoint serves live staking data from the backend API
+export async function fetchStakingData(fetchFn = fetch, url = '/api/staking') {
+  const resp = await fetchFn(url);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function loadStakingStatus(fetchFn = fetch) {
+  const total = document.getElementById('total-staked');
+  const rewards = document.getElementById('user-rewards');
+  const errorEl = document.getElementById('staking-error');
+  const percentEl = document.getElementById('staking-percent');
+  const progressBar = document.getElementById('staking-progress-bar');
+  let data;
+  try {
+    data = await fetchStakingData(fetchFn);
+  } catch (err) {
+    console.error('Failed to fetch staking info', err);
+    try {
+      const resp = await fetchFn('/staking.json');
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      data = await resp.json();
+    } catch (fallbackErr) {
+      console.error('Failed to fetch fallback staking info', fallbackErr);
+      if (total) total.textContent = translate('staking_unavailable');
+      if (rewards) rewards.textContent = translate('staking_unavailable');
+      if (percentEl) percentEl.textContent = translate('staking_unavailable');
+      if (progressBar) progressBar.style.width = '0%';
+      if (errorEl) {
+        errorEl.textContent = translate('staking_error_unavailable');
+        errorEl.hidden = false;
+      }
+      return;
+    }
+  }
+  if (total) total.textContent = data.totalStaked;
+  if (rewards) rewards.textContent = data.userRewards;
+  const percent =
+    data.totalSupply
+      ? (Number(data.totalStaked) / Number(data.totalSupply)) * 100
+      : Number(data.stakingPercent ?? 0);
+  if (percentEl) percentEl.textContent = `${percent.toFixed(2)}%`;
+  if (progressBar) progressBar.style.width = `${percent}%`;
+}

--- a/app/theme.js
+++ b/app/theme.js
@@ -1,0 +1,38 @@
+export function isDark() {
+  return (
+    document.body.classList.contains('dark-mode') ||
+    (!document.body.classList.contains('light-mode') &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches)
+  );
+}
+export function updateThemeIcon(themeToggle) {
+  if (!themeToggle) return;
+  // Clear existing icon/content
+  themeToggle.textContent = '';
+
+  const icon = document.createElement('i');
+  icon.classList.add('material-symbols-outlined');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = isDark() ? 'light_mode' : 'dark_mode';
+
+  themeToggle.appendChild(icon);
+}
+export function setTheme(theme, themeToggle = document.querySelector('.theme-toggle')) {
+  document.body.classList.toggle('dark-mode', theme === 'dark');
+  document.body.classList.toggle('light-mode', theme === 'light');
+  if (theme) {
+    localStorage.setItem('theme', theme);
+  }
+  updateThemeIcon(themeToggle);
+}
+export function initTheme() {
+  const themeToggle = document.querySelector('.theme-toggle');
+  if (!themeToggle) return;
+  const saved = localStorage.getItem('theme');
+  if (saved) setTheme(saved, themeToggle);
+  else updateThemeIcon(themeToggle);
+  themeToggle.addEventListener('click', () => {
+    const next = isDark() ? 'light' : 'dark';
+    setTheme(next, themeToggle);
+  });
+}

--- a/index.html
+++ b/index.html
@@ -999,6 +999,6 @@
       <i class="material-symbols-outlined" aria-hidden="true">arrow_upward</i>
     </button>
 
-    <script type="module" src="bundle.js"></script>
+    <script type="module" src="app/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Port TypeScript frontend logic into `/app` directory as plain ES modules.
- Consolidate bootstrap into `app/main.js` and load from `index.html`.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b142e271f88327b266c10781fe5d4e