### PR TITLE
feat: add lightweight i18n module

### DIFF
--- a/app/i18n.js
+++ b/app/i18n.js
@@ -67,7 +67,7 @@ export async function loadLanguage(lang) {
   return lang;
 }
 
-export function translate(key, lang = currentLang) {
+export function t(key, lang = currentLang) {
   return (
     translations[lang]?.[key] ||
     translations[DEFAULT_LANG]?.[key] ||
@@ -79,11 +79,11 @@ export function translate(key, lang = currentLang) {
 export async function setLanguage(lang) {
   const loadedLang = await loadLanguage(lang);
   if (!loadedLang) {
-    showNotice(translate('notice_load_fail', DEFAULT_LANG));
+    showNotice(t('notice_load_fail', DEFAULT_LANG));
     return;
   }
   if (loadedLang !== lang) {
-    showNotice(translate('notice_lang_unavailable', loadedLang));
+    showNotice(t('notice_lang_unavailable', loadedLang));
   }
   lang = loadedLang;
   currentLang = lang;
@@ -156,7 +156,7 @@ export async function loadWhitepaper(lang) {
     window.applyFancyTitles?.();
   } catch (err) {
     console.error('Failed to load whitepaper:', err);
-    const fallback = `<p>${translate('notice_whitepaper_unavailable', lang)}</p>`;
+    const fallback = `<p>${t('notice_whitepaper_unavailable', lang)}</p>`;
     container.innerHTML = DOMPurify.sanitize(fallback);
   }
 }
@@ -191,6 +191,6 @@ export async function initI18n() {
 }
 
 if (typeof window !== 'undefined') {
-  window.translate = translate;
+  window.t = t;
   window.applyTokenomics = applyTokenomics;
 }

--- a/app/main.js
+++ b/app/main.js
@@ -3,7 +3,7 @@ import { loadStakingStatus } from './staking.js';
 import {
   initI18n,
   loadLanguage,
-  translate,
+  t,
   DEFAULT_LANG,
   currentLang,
 } from './i18n.js';
@@ -44,13 +44,13 @@ if (newsletterForm && newsletterMessage) {
         body: JSON.stringify({ email: emailInput.value }),
       });
       if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
-      newsletterMessage.textContent = translate(
+      newsletterMessage.textContent = t(
         'newsletter_success',
         resolvedLang
       );
     } catch (err) {
       console.error('Newsletter subscription failed:', err);
-      newsletterMessage.textContent = translate(
+      newsletterMessage.textContent = t(
         'newsletter_error',
         resolvedLang
       );
@@ -107,12 +107,12 @@ async function loadPartners() {
           h(
             'span',
             { 'data-i18n': p.nameKey },
-            translate(p.nameKey)
+            t(p.nameKey)
           ),
           h(
             'p',
             { 'data-i18n': p.descKey },
-            translate(p.descKey)
+            t(p.descKey)
           )
         )
       );
@@ -169,7 +169,7 @@ async function loadResources() {
         h(
           'a',
           linkProps,
-          h('span', { 'data-i18n': r.nameKey }, translate(r.nameKey))
+          h('span', { 'data-i18n': r.nameKey }, t(r.nameKey))
         )
       );
       list.append(li);
@@ -196,14 +196,14 @@ async function loadTeam() {
           { href: m.link, target: '_blank', rel: 'noopener noreferrer' },
           h('img', {
             src: m.image,
-            alt: translate(m.altKey),
+            alt: t(m.altKey),
             loading: 'lazy',
             'data-i18n-alt': m.altKey,
           }),
           h('h3', {}, m.name)
         ),
-        h('p', { 'data-i18n': m.roleKey }, translate(m.roleKey)),
-        h('p', { 'data-i18n': m.bioKey }, translate(m.bioKey))
+        h('p', { 'data-i18n': m.roleKey }, t(m.roleKey)),
+        h('p', { 'data-i18n': m.bioKey }, t(m.bioKey))
       );
       grid.append(member);
     });

--- a/app/router.js
+++ b/app/router.js
@@ -1,5 +1,6 @@
 import { setState } from './state/store.js';
 import { mount } from './lib/dom.js';
+import { currentLang, loadLanguage, setLanguage } from './i18n.js';
 
 const routes = {
   '/': async () => {
@@ -62,8 +63,10 @@ async function render() {
   const hash = location.hash.replace(/^#/, '') || '/';
   const path = hash.startsWith('/') ? hash : `/${hash}`;
   const loader = routes[path] || routes['/'];
+  await loadLanguage(currentLang);
   const view = await loader();
   mount(root, view);
+  await setLanguage(currentLang);
   setState({ route: path });
 }
 

--- a/app/staking.js
+++ b/app/staking.js
@@ -1,4 +1,4 @@
-import { translate } from './i18n.js';
+import { t } from './i18n.js';
 
 // Default endpoint serves live staking data from the backend API
 export async function fetchStakingData(fetchFn = fetch, url = '/api/staking') {
@@ -24,12 +24,12 @@ export async function loadStakingStatus(fetchFn = fetch) {
       data = await resp.json();
     } catch (fallbackErr) {
       console.error('Failed to fetch fallback staking info', fallbackErr);
-      if (total) total.textContent = translate('staking_unavailable');
-      if (rewards) rewards.textContent = translate('staking_unavailable');
-      if (percentEl) percentEl.textContent = translate('staking_unavailable');
+      if (total) total.textContent = t('staking_unavailable');
+      if (rewards) rewards.textContent = t('staking_unavailable');
+      if (percentEl) percentEl.textContent = t('staking_unavailable');
       if (progressBar) progressBar.style.width = '0%';
       if (errorEl) {
-        errorEl.textContent = translate('staking_error_unavailable');
+        errorEl.textContent = t('staking_error_unavailable');
         errorEl.hidden = false;
       }
       return;

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -10,15 +10,15 @@ global.document = dom.window.document;
 global.localStorage = dom.window.localStorage;
 global.location = dom.window.location;
 
-test('translate returns key when missing', async () => {
-  const { translations, translate } = await import('./i18n.ts');
+test('t returns key when missing', async () => {
+  const { translations, t } = await import('./i18n.ts');
   translations.en = { hello: 'Hello' };
-  assert.equal(translate('hello', 'en'), 'Hello');
-  assert.equal(translate('unknown', 'en'), 'unknown');
+  assert.equal(t('hello', 'en'), 'Hello');
+  assert.equal(t('unknown', 'en'), 'unknown');
 });
 
 test('loadWhitepaper uses translated fallback', async () => {
-  const { translations, translate, loadWhitepaper } = await import('./i18n.ts');
+  const { translations, t, loadWhitepaper } = await import('./i18n.ts');
   translations.en = {
     notice_whitepaper_unavailable: 'Whitepaper not available.',
   };
@@ -34,7 +34,7 @@ test('loadWhitepaper uses translated fallback', async () => {
   }
   assert.equal(
     container.innerHTML,
-    `<p>${translate('notice_whitepaper_unavailable')}</p>`
+    `<p>${t('notice_whitepaper_unavailable')}</p>`
   );
 });
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -67,7 +67,7 @@ export async function loadLanguage(lang) {
   return lang;
 }
 
-export function translate(key, lang = currentLang) {
+export function t(key: string, lang = currentLang) {
   return (
     translations[lang]?.[key] ||
     translations[DEFAULT_LANG]?.[key] ||
@@ -79,11 +79,11 @@ export function translate(key, lang = currentLang) {
 export async function setLanguage(lang) {
   const loadedLang = await loadLanguage(lang);
   if (!loadedLang) {
-    showNotice(translate('notice_load_fail', DEFAULT_LANG));
+    showNotice(t('notice_load_fail', DEFAULT_LANG));
     return;
   }
   if (loadedLang !== lang) {
-    showNotice(translate('notice_lang_unavailable', loadedLang));
+    showNotice(t('notice_lang_unavailable', loadedLang));
   }
   lang = loadedLang;
   currentLang = lang;
@@ -158,7 +158,7 @@ export async function loadWhitepaper(lang) {
     window.applyFancyTitles?.();
   } catch (err) {
     console.error('Failed to load whitepaper:', err);
-    const fallback = `<p>${translate('notice_whitepaper_unavailable', lang)}</p>`;
+    const fallback = `<p>${t('notice_whitepaper_unavailable', lang)}</p>`;
     container.innerHTML = DOMPurify.sanitize(fallback);
   }
 }
@@ -197,12 +197,12 @@ export async function initI18n() {
 // Expose helpers for standalone pages
 declare global {
   interface Window {
-    translate?: typeof translate;
+    t?: typeof t;
     applyTokenomics?: typeof applyTokenomics;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.translate = translate;
+  window.t = t;
   window.applyTokenomics = applyTokenomics;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { loadStakingStatus } from './staking.ts';
 import {
   initI18n,
   loadLanguage,
-  translate,
+  t,
   DEFAULT_LANG,
   currentLang,
 } from './i18n.ts';
@@ -44,13 +44,13 @@ if (newsletterForm && newsletterMessage) {
         body: JSON.stringify({ email: emailInput.value }),
       });
       if (!resp.ok) throw new Error(`HTTP error ${resp.status}`);
-      newsletterMessage.textContent = translate(
+      newsletterMessage.textContent = t(
         'newsletter_success',
         resolvedLang
       );
     } catch (err) {
       console.error('Newsletter subscription failed:', err);
-      newsletterMessage.textContent = translate(
+      newsletterMessage.textContent = t(
         'newsletter_error',
         resolvedLang
       );
@@ -108,11 +108,11 @@ async function loadPartners() {
 
       const name = document.createElement('span');
       name.setAttribute('data-i18n', p.nameKey);
-      name.textContent = translate(p.nameKey);
+      name.textContent = t(p.nameKey);
 
       const desc = document.createElement('p');
       desc.setAttribute('data-i18n', p.descKey);
-      desc.textContent = translate(p.descKey);
+      desc.textContent = t(p.descKey);
 
       link.append(img, icon, name, desc);
       item.append(link);
@@ -169,7 +169,7 @@ async function loadResources() {
 
       const label = document.createElement('span');
       label.setAttribute('data-i18n', r.nameKey);
-      label.textContent = translate(r.nameKey);
+      label.textContent = t(r.nameKey);
 
       link.append(label);
       li.append(icon, link);
@@ -207,7 +207,7 @@ async function loadTeam() {
 
       const img = document.createElement('img');
       img.src = m.image;
-      img.alt = translate(m.altKey);
+      img.alt = t(m.altKey);
       img.loading = 'lazy';
       img.setAttribute('data-i18n-alt', m.altKey);
 
@@ -218,11 +218,11 @@ async function loadTeam() {
 
       const role = document.createElement('p');
       role.setAttribute('data-i18n', m.roleKey);
-      role.textContent = translate(m.roleKey);
+      role.textContent = t(m.roleKey);
 
       const bio = document.createElement('p');
       bio.setAttribute('data-i18n', m.bioKey);
-      bio.textContent = translate(m.bioKey);
+      bio.textContent = t(m.bioKey);
 
       member.append(link, role, bio);
       grid.append(member);

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,5 @@
 import { setState } from './state/store.ts';
+import { currentLang, loadLanguage, setLanguage } from './i18n.ts';
 
 const routes: Record<string, () => Promise<HTMLElement>> = {
   '/': async () => {
@@ -66,8 +67,10 @@ async function render() {
   const hash = window.location.hash.replace(/^#/, '') || '/';
   const path = hash.startsWith('/') ? hash : `/${hash}`;
   const loader = routes[path] || routes['/'];
+  await loadLanguage(currentLang);
   const view = await loader();
   mount(root, view);
+  await setLanguage(currentLang);
   setState({ route: path });
 }
 

--- a/src/staking.ts
+++ b/src/staking.ts
@@ -1,4 +1,4 @@
-import { translate } from './i18n.ts';
+import { t } from './i18n.ts';
 
 // Default endpoint serves live staking data from the backend API
 export async function fetchStakingData(fetchFn = fetch, url = '/api/staking') {
@@ -24,12 +24,12 @@ export async function loadStakingStatus(fetchFn = fetch) {
       data = await resp.json();
     } catch (fallbackErr) {
       console.error('Failed to fetch fallback staking info', fallbackErr);
-      if (total) total.textContent = translate('staking_unavailable');
-      if (rewards) rewards.textContent = translate('staking_unavailable');
-      if (percentEl) percentEl.textContent = translate('staking_unavailable');
+      if (total) total.textContent = t('staking_unavailable');
+      if (rewards) rewards.textContent = t('staking_unavailable');
+      if (percentEl) percentEl.textContent = t('staking_unavailable');
       if (progressBar) progressBar.style.width = '0%';
       if (errorEl) {
-        errorEl.textContent = translate('staking_error_unavailable');
+        errorEl.textContent = t('staking_error_unavailable');
         errorEl.hidden = false;
       }
       return;


### PR DESCRIPTION
## Summary
- add custom i18n utility with `t()` lookup and language persistence
- drop i18next usage and update modules to use new translator
- ensure router loads translations before rendering views

## Testing
- `npm run build:web` *(fails: Could not resolve ./views/...)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1495d59148327ace8dd31527e6a6b