### PR TITLE
Use relative paths for staking data fetch

### DIFF
--- a/app/staking.js
+++ b/app/staking.js
@@ -1,7 +1,7 @@
 import { t } from './i18n.js';
 
 // Default endpoint serves live staking data from the backend API
-export async function fetchStakingData(fetchFn = fetch, url = '/api/staking') {
+export async function fetchStakingData(fetchFn = fetch, url = 'api/staking') {
   const resp = await fetchFn(url);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();
@@ -19,7 +19,7 @@ export async function loadStakingStatus(fetchFn = fetch) {
   } catch (err) {
     console.error('Failed to fetch staking info', err);
     try {
-      const resp = await fetchFn('/staking.json');
+      const resp = await fetchFn('staking.json');
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       data = await resp.json();
     } catch (fallbackErr) {

--- a/app/theme.js
+++ b/app/theme.js
@@ -1,5 +1,5 @@
 import { h } from './lib/dom.js';
-import { setState, getState } from './state/store.js';
+import { setState } from './state/store.js';
 
 export function isDark() {
   return (


### PR DESCRIPTION
## Summary
- fetch staking data from `api/staking` relative to current base path
- load fallback staking data from `staking.json`
- remove unused `getState` import in theme module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15b7460b48327b965806436dd2c57