### PR TITLE
feat: make staking API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,16 @@ npm test
 
 ## Staking Data
 
-The app first attempts to load live staking information from `/api/staking`.
-If that request fails it automatically falls back to the static `staking.json`
-file in the project root. When using this fallback, remember to refresh the
-file's contents periodically or plan to replace it with a proper backend API so
-that staking figures do not become outdated.
+The app first attempts to load live staking information from a backend API. If
+you have a live service, expose its base URL via `window.STAKING_API_URL` (for
+example `https://api.example.com/api`) before loading `app/main.js`. The helper
+`fetchStakingData` will request the `/staking` route from that base.
+
+If no backend is configured or the request fails, the code falls back to the
+static `staking.json` file in the project root. Ensure this file is present in
+the deployment root (e.g., GitHub Pages); copy the repository’s version there if
+it is missing. Refresh its contents periodically so staking figures do not
+become outdated.
 
 ## Local Development
 

--- a/app/main.js
+++ b/app/main.js
@@ -214,7 +214,7 @@ async function loadTeam() {
 
 initTheme();
 initI18n();
-loadStakingStatus();
+loadStakingStatus(fetch, window.STAKING_API_URL);
 loadPartners();
 loadResources();
 loadTeam();

--- a/app/staking.js
+++ b/app/staking.js
@@ -1,13 +1,22 @@
 import { t } from './i18n.js';
 
-// Default endpoint serves live staking data from the backend API
-export async function fetchStakingData(fetchFn = fetch, url = 'api/staking') {
-  const resp = await fetchFn(url);
+// Fetch staking data either from a configured backend or the default path
+export async function fetchStakingData(
+  fetchFn = fetch,
+  apiBase = window.STAKING_API_URL
+) {
+  const endpoint = apiBase
+    ? `${apiBase.replace(/\/$/, '')}/staking`
+    : 'api/staking';
+  const resp = await fetchFn(endpoint);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();
 }
 
-export async function loadStakingStatus(fetchFn = fetch) {
+export async function loadStakingStatus(
+  fetchFn = fetch,
+  apiBase = window.STAKING_API_URL
+) {
   const total = document.getElementById('total-staked');
   const rewards = document.getElementById('user-rewards');
   const errorEl = document.getElementById('staking-error');
@@ -15,7 +24,7 @@ export async function loadStakingStatus(fetchFn = fetch) {
   const progressBar = document.getElementById('staking-progress-bar');
   let data;
   try {
-    data = await fetchStakingData(fetchFn);
+    data = await fetchStakingData(fetchFn, apiBase);
   } catch (err) {
     console.error('Failed to fetch staking info', err);
     try {


### PR DESCRIPTION
## Summary
- allow frontend to fetch staking stats from configurable `window.STAKING_API_URL`
- wire API base into `loadStakingStatus`
- document backend config and `staking.json` placement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15c3d19d88327a78de4ff8eefb269