### PR TITLE
Default staking endpoint to local JSON

### DIFF
--- a/app/staking.js
+++ b/app/staking.js
@@ -7,7 +7,7 @@ export async function fetchStakingData(
 ) {
   const endpoint = apiBase
     ? `${apiBase.replace(/\/$/, '')}/staking`
-    : 'api/staking';
+    : 'staking.json';
   const resp = await fetchFn(endpoint);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();

--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
       crossorigin="anonymous"
       defer
     ></script>
+    <script>
+      window.STAKING_API_URL = 'staking.json';
+    </script>
   </head>
   <body data-page="index">
     <a class="skip-link" href="#main">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Default staking endpoint to `staking.json` when no API base is provided
- Define `window.STAKING_API_URL` in `index.html` for local data loading

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15e63874883279b2631c254c3a29d