### PR TITLE
chore: streamline whitepaper tokenomics scripts

### DIFF
--- a/whitepaper/ar/index.html
+++ b/whitepaper/ar/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/de/index.html
+++ b/whitepaper/de/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/en/index.html
+++ b/whitepaper/en/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/es/index.html
+++ b/whitepaper/es/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/fr/index.html
+++ b/whitepaper/fr/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/hi/index.html
+++ b/whitepaper/hi/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/ja/index.html
+++ b/whitepaper/ja/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/ko/index.html
+++ b/whitepaper/ko/index.html
@@ -80,8 +80,6 @@
   </ul>
 </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/pt/index.html
+++ b/whitepaper/pt/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/ru/index.html
+++ b/whitepaper/ru/index.html
@@ -80,8 +80,6 @@
         </ul>
       </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>

--- a/whitepaper/zh/index.html
+++ b/whitepaper/zh/index.html
@@ -80,8 +80,6 @@
           </ul>
         </section>
 <script type="module">
-  import '../../bundle.js';
-  window.addEventListener('DOMContentLoaded', () => {
-    window.applyTokenomics?.();
-  });
+  import { applyTokenomics } from '../../app/i18n.js';
+  applyTokenomics();
 </script>


### PR DESCRIPTION
## Summary
- remove missing bundle.js import from each localized whitepaper
- load tokenomics via app/i18n.js and call applyTokenomics directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15ef9d2a48327b71c78b9191a30ae