### PR TITLE
Remove STAKING_API_URL to default to local staking.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
       defer
     ></script>
     <script>
-      window.STAKING_API_URL = 'staking.json';
+      // window.STAKING_API_URL = 'staking.json';
     </script>
   </head>
   <body data-page="index">


### PR DESCRIPTION
## Summary
- Comment out STAKING_API_URL definition so staking data is loaded from local staking.json by default.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1614bef1483278903a78e86a84675