### PR TITLE
Link modern-normalize and inherit box-sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,10 @@
       href="https://fonts.googleapis.com/css2?family=Poppins&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/2.0.0/modern-normalize.min.css"
+    />
     <link rel="stylesheet" href="style.css" />
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"

--- a/style.css
+++ b/style.css
@@ -1,3 +1,12 @@
+html {
+  box-sizing: border-box;
+  scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
+}
+
+*,*::before,*::after {
+  box-sizing: inherit;
+}
+
 /* light theme variables */
 :root {
   --bg: #ffffff;
@@ -86,16 +95,6 @@ body {
   font-family: 'Roboto', sans-serif;
   font-size: 100%;
   line-height: 1.6;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top, 0));
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Summary
- include modern-normalize CSS via CDN before main stylesheet
- set html box-sizing to border-box and inherit for all elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b163f4c22883279a08681c937eb40e