### PR TITLE
feat: add large-screen breakpoints

### DIFF
--- a/style.css
+++ b/style.css
@@ -726,6 +726,148 @@ body.dark-mode .footer {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
 }
 
+@media (min-width: 1024px) {
+  :root {
+    --space-sm: 1.25rem;
+    --space-md: 2rem;
+    --space-lg: 3rem;
+    --nav-height: 70px;
+  }
+
+  html,
+  body {
+    font-size: 105%;
+  }
+
+  .navbar {
+    padding: var(--space-md)
+      calc(var(--space-lg) + env(safe-area-inset-right, 0)) var(--space-md)
+      calc(var(--space-lg) + env(safe-area-inset-left, 0));
+  }
+
+  .hero {
+    padding: calc(var(--space-lg) * 4) var(--space-lg);
+  }
+
+  .hero h1 {
+    font-size: 4.5rem;
+  }
+
+  .hero p {
+    font-size: 1.25rem;
+    max-width: 700px;
+  }
+
+  section {
+    max-width: 1200px;
+    padding: calc(var(--space-lg) * 3) var(--space-md);
+  }
+
+  section h2 {
+    font-size: 2rem;
+  }
+
+  section h3 {
+    font-size: 1.4rem;
+  }
+
+  #about .about-grid {
+    gap: calc(var(--space-lg) * 1.5);
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: calc(var(--space-lg) * 1.5);
+    max-width: 1200px;
+  }
+
+  .logo-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: calc(var(--space-lg) * 1.5);
+    max-width: 1000px;
+  }
+
+  .team-grid {
+    gap: calc(var(--space-lg) * 1.5);
+  }
+
+  .btn {
+    padding: 1rem 2rem;
+    font-size: 1.1rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  :root {
+    --space-sm: 1.5rem;
+    --space-md: 2.5rem;
+    --space-lg: 4rem;
+    --nav-height: 80px;
+  }
+
+  html,
+  body {
+    font-size: 110%;
+  }
+
+  .navbar {
+    padding: var(--space-md)
+      calc(var(--space-lg) + env(safe-area-inset-right, 0)) var(--space-md)
+      calc(var(--space-lg) + env(safe-area-inset-left, 0));
+  }
+
+  .hero {
+    padding: calc(var(--space-lg) * 5) var(--space-lg);
+  }
+
+  .hero h1 {
+    font-size: 5rem;
+  }
+
+  .hero p {
+    font-size: 1.5rem;
+    max-width: 800px;
+  }
+
+  section {
+    max-width: 1400px;
+    padding: calc(var(--space-lg) * 4) var(--space-lg);
+  }
+
+  section h2 {
+    font-size: 2.2rem;
+  }
+
+  section h3 {
+    font-size: 1.6rem;
+  }
+
+  #about .about-grid {
+    gap: calc(var(--space-lg) * 2);
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: calc(var(--space-lg) * 2);
+    max-width: 1400px;
+  }
+
+  .logo-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: calc(var(--space-lg) * 2);
+    max-width: 1200px;
+  }
+
+  .team-grid {
+    gap: calc(var(--space-lg) * 2);
+  }
+
+  .btn {
+    padding: 1.2rem 2.4rem;
+    font-size: 1.2rem;
+  }
+}
+
 @media (max-width: 768px) {
   :root {
     --space-sm: 0.75rem;


### PR DESCRIPTION
## Summary
- add responsive @media blocks for 1024px and 1440px breakpoints
- scale typography, spacing, and grid layouts for large screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1667f94848327b21eb16bdf26a429