### PR TITLE
Update router to set page dataset before language change

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -62,6 +62,7 @@ async function render() {
   if (!root) return;
   const hash = location.hash.replace(/^#/, '') || '/';
   const path = hash.startsWith('/') ? hash : `/${hash}`;
+  document.body.dataset.page = path.replace(/^\//, '') || 'index';
   const loader = routes[path] || routes['/'];
   await loadLanguage(currentLang);
   const view = await loader();


### PR DESCRIPTION
## Summary
- ensure router updates `document.body.dataset.page` from hash path
- update dataset prior to `setLanguage` so page-specific titles and translations are applied

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51ca51a208327b065078a604420dd