### PR TITLE
Apply fancy titles before translation

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,6 +1,7 @@
 import { setState } from './state/store.js';
 import { mount } from './lib/dom.js';
 import { currentLang, loadLanguage, setLanguage } from './i18n.js';
+import { applyFancyTitles } from './fancy-title.js';
 
 const routes = {
   '/': async () => {
@@ -67,6 +68,7 @@ async function render() {
   await loadLanguage(currentLang);
   const view = await loader();
   mount(root, view);
+  applyFancyTitles();
   await setLanguage(currentLang);
   setState({ route: path });
 }


### PR DESCRIPTION
## Summary
- call `applyFancyTitles()` in router after mounting a view
- translate fancy titles by invoking `setLanguage` after the transformation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51d9db5d08327a67e214e1bc09b6c