### PR TITLE
chore: guard unstake against reentrancy

### DIFF
--- a/contracts/NFTStaking.sol
+++ b/contracts/NFTStaking.sol
@@ -52,7 +52,7 @@ contract NFTStaking is Ownable, ReentrancyGuard {
         emit Staked(msg.sender, tokenId);
     }
 
-    function unstake(uint256 tokenId) external updateReward(msg.sender) {
+    function unstake(uint256 tokenId) external nonReentrant updateReward(msg.sender) {
         require(tokenOwner[tokenId] == msg.sender, "Not owner");
         stakers[msg.sender].balance -= 1;
         tokenOwner[tokenId] = address(0);


### PR DESCRIPTION
## Summary
- protect `unstake` from reentrancy by adding `nonReentrant` modifier

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52abb6a248327a0134d94a9e6e919