### PR TITLE
feat: use historical voting snapshots

### DIFF
--- a/contracts/HallyuDAO.sol
+++ b/contracts/HallyuDAO.sol
@@ -6,6 +6,10 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IHallyuToken is IERC20 {
     function mint(address to, uint256 amount) external;
+    function getPastVotes(address account, uint256 blockNumber)
+        external
+        view
+        returns (uint256);
 }
 
 /// @title HallyuDAO
@@ -18,6 +22,7 @@ contract HallyuDAO is Ownable {
         string description;
         uint256 start;
         uint256 end;
+        uint256 snapshot;
         uint256 forVotes;
         uint256 againstVotes;
         bool executed;
@@ -62,6 +67,7 @@ contract HallyuDAO is Ownable {
         p.description = description;
         p.start = block.timestamp;
         p.end = block.timestamp + VOTING_PERIOD;
+        p.snapshot = block.number - 1;
         emit ProposalCreated(proposalCount, msg.sender, description);
         return proposalCount;
     }
@@ -70,7 +76,7 @@ contract HallyuDAO is Ownable {
         Proposal storage p = proposals[id];
         require(block.timestamp >= p.start && block.timestamp <= p.end, "voting closed");
         require(!p.voted[msg.sender], "already voted");
-        uint256 weight = token.balanceOf(msg.sender);
+        uint256 weight = token.getPastVotes(msg.sender, p.snapshot);
         require(weight > 0, "no voting power");
         if (support) {
             p.forVotes += weight;

--- a/contracts/HallyuToken.sol
+++ b/contracts/HallyuToken.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Capped.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
-contract HallyuToken is ERC20Capped, ERC20Burnable, Ownable {
+contract HallyuToken is ERC20Capped, ERC20Burnable, ERC20Votes, Ownable {
     uint256 public constant INITIAL_SUPPLY = 10_000_000_000 * 10 ** 18;
     uint256 public constant CAP = INITIAL_SUPPLY;
 
@@ -17,6 +19,7 @@ contract HallyuToken is ERC20Capped, ERC20Burnable, Ownable {
     constructor(address daoAddress)
         ERC20("Hallyu Chain", "HALL")
         ERC20Capped(CAP)
+        EIP712("Hallyu Chain", "1")
         Ownable(msg.sender)
     {
         dao = daoAddress;
@@ -44,7 +47,7 @@ contract HallyuToken is ERC20Capped, ERC20Burnable, Ownable {
 
     function _update(address from, address to, uint256 value)
         internal
-        override(ERC20, ERC20Capped)
+        override(ERC20, ERC20Capped, ERC20Votes)
     {
         if (from != address(0) && to != address(0)) {
             uint256 burnAmount = (value * 3) / 100;

--- a/test/HallyuDAO.js
+++ b/test/HallyuDAO.js
@@ -18,6 +18,8 @@ describe("HallyuDAO", function () {
     await dao.setToken(await token.getAddress());
     await token.transfer(voter1.address, ethers.parseUnits("100", 18));
     await token.transfer(voter2.address, ethers.parseUnits("100", 18));
+    await token.connect(voter1).delegate(voter1.address);
+    await token.connect(voter2).delegate(voter2.address);
   });
 
   it("mints tokens via passed proposal", async function () {


### PR DESCRIPTION
## Summary
- integrate ERC20Votes snapshot interface for token and DAO
- track snapshot block when proposals are created
- vote weight now comes from historical voting power

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b52de41dc88327ace005fc12e081ed