### PR TITLE
feat: add voting snapshot support

### DIFF
--- a/contracts/HallyuDAO.sol
+++ b/contracts/HallyuDAO.sol
@@ -2,15 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-interface IHallyuToken is IERC20 {
-    function mint(address to, uint256 amount) external;
-    function getPastVotes(address account, uint256 blockNumber)
-        external
-        view
-        returns (uint256);
-}
+import "./interfaces/IHallyuToken.sol";
 
 /// @title HallyuDAO
 /// @notice Simple token-based governance for HallyuToken

--- a/contracts/HallyuToken.sol
+++ b/contracts/HallyuToken.sol
@@ -6,8 +6,9 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "./interfaces/IHallyuToken.sol";
 
-contract HallyuToken is ERC20Capped, ERC20Burnable, ERC20Votes, Ownable {
+contract HallyuToken is ERC20Capped, ERC20Burnable, ERC20Votes, Ownable, IHallyuToken {
     uint256 public constant INITIAL_SUPPLY = 10_000_000_000 * 10 ** 18;
     uint256 public constant CAP = INITIAL_SUPPLY;
 

--- a/contracts/interfaces/IHallyuToken.sol
+++ b/contracts/interfaces/IHallyuToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/governance/utils/IVotes.sol";
+
+interface IHallyuToken is IERC20, IVotes {
+    function mint(address to, uint256 amount) external;
+}
+


### PR DESCRIPTION
## Summary
- add IHallyuToken interface extending ERC20Votes
- import IHallyuToken in DAO and use snapshots for voting power
- implement IHallyuToken in HallyuToken

## Testing
- `npm run compile` (fails: Couldn't download compiler version list)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53b00797c83278e0d81645a86f71e