### PR TITLE
chore: prune frontend workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,36 +25,6 @@
         "node": ">=18.0.0"
       }
     },
-    "frontend": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "gsap": "^3.13.0",
-        "i18next": "^25.4.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-helmet": "^6.1.0",
-        "react-i18next": "^15.7.1"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.33.0",
-        "@testing-library/jest-dom": "^6.8.0",
-        "@testing-library/react": "^15.0.7",
-        "@testing-library/user-event": "^14.6.1",
-        "@types/react": "^18.3.24",
-        "@types/react-dom": "^18.3.4",
-        "@types/react-helmet": "^6.1.11",
-        "@vitejs/plugin-react": "^5.0.0",
-        "eslint": "^9.33.0",
-        "eslint-plugin-react-hooks": "^5.2.0",
-        "eslint-plugin-react-refresh": "^0.4.20",
-        "globals": "^16.3.0",
-        "jsdom": "^24.1.3",
-        "typescript": "^5.6.3",
-        "vite": "^7.1.2",
-        "vitest": "^3.2.4"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",


### PR DESCRIPTION
## Summary
- remove extraneous `frontend` workspace from `package-lock.json`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b53af04aa483278e4da9fcf01ad195