### PR TITLE
chore: remove obsolete frontend build step

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -16,10 +16,9 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm run build --workspace frontend
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: frontend/dist
+          publish_dir: .
           destination_dir: frontend
 


### PR DESCRIPTION
## Summary
- remove frontend workspace build step from deploy workflow
- publish root directory in GitHub Pages deployment

## Testing
- `npm ci`
- `npm run check-locales`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53bfe56cc832785ed331b0c07ed4d