### PR TITLE
fix: Implement missing mint function in HallyuToken

### DIFF
--- a/contracts/HallyuToken.sol
+++ b/contracts/HallyuToken.sol
@@ -37,5 +37,9 @@ contract HallyuToken is ERC20Capped, ERC20Burnable, ERC20Votes, Ownable, IHallyu
             super._update(from, to, value);
         }
     }
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
 }
 


### PR DESCRIPTION
The HallyuToken contract was missing the `mint` function required by the `IHallyuToken` interface. This caused a compilation error and made it impossible to create new tokens.

This commit adds the `mint` function to the `HallyuToken` contract, restricted to the owner, to allow for the creation of new tokens up to the defined cap.